### PR TITLE
refactor(test): replaces chai with node:assert

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -193,11 +193,29 @@ module.exports = {
     reporterOptions: {
       dot: {
         collapsePattern: "node_modules/[^/]+",
-
         theme: {
           graph: {
             splines: "ortho",
           },
+          modules: [
+            {
+              criteria: {
+                matchesReaches: true,
+              },
+              attributes: {
+                fillcolor: "lime",
+                penwidth: 2,
+              },
+            },
+            {
+              criteria: {
+                source: ".spec.ts",
+              },
+              attributes: {
+                fillcolor: "#ccccff",
+              },
+            },
+          ],
         },
       },
       text: {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "build": "rm -rf dist && node tools/get-version.mjs > src/version.ts && tsc",
     "depcruise": "depcruise src --config .dependency-cruiser.cjs",
     "depcruise:graph": "depcruise src --include-only '^(src)' --config --output-type dot | dot -T svg | depcruise-wrap-stream-in-html > dependency-graph.html",
-    "depcruise:graph:dev": "depcruise src --include-only '^(src)' --prefix vscode://file/$(pwd)/ --config --output-type dot | dot -T svg | depcruise-wrap-stream-in-html | browser",
-    "depcruise:graph:diff:mermaid": "depcruise src --include-only '^(src)' --config --output-type mermaid --output-to - --reaches \"$(watskeburt $SHA -T regex)\"",
+    "depcruise:graph:dev": "depcruise src --prefix vscode://file/$(pwd)/ --config --output-type dot | dot -T svg | depcruise-wrap-stream-in-html | browser",
+    "depcruise:graph:diff:dev": "depcruise src --prefix vscode://file/$(pwd)/ --config --output-type dot --reaches \"$(watskeburt $SHA -T regex)\"| dot -T svg | depcruise-wrap-stream-in-html | browser",
+    "depcruise:graph:diff:mermaid": "depcruise src --config --output-type mermaid --output-to - --reaches \"$(watskeburt $SHA -T regex)\"",
     "depcruise:html": "depcruise src --progress --config --output-type err-html --output-to dependency-violation-report.html",
     "format": "prettier --loglevel warn --write \"**/*.{md,ts,json,yml}\"",
     "scm:stage": "git add .",
@@ -49,11 +50,9 @@
     "url": "https://github.com/sverweij/virtual-code-owners/issues"
   },
   "devDependencies": {
-    "@types/chai": "4.3.3",
     "@types/js-yaml": "4.0.5",
     "@types/node": "18.8.5",
     "c8": "7.12.0",
-    "chai": "4.3.6",
     "dependency-cruiser": "11.16.1",
     "mocha": "10.0.0",
     "prettier": "2.7.1",

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -1,6 +1,5 @@
-import { expect } from "chai";
+import { equal } from "node:assert";
 import { convert, ITeamMap } from "./convert-virtual-code-owners.js";
-
 describe("doSomething does something", () => {
   const lCodeOwners = `# here's a comment
 * @everyone
@@ -12,7 +11,7 @@ libs/after-sales @team-after-sales
 tools/ @team-tgif`;
 
   it("leaves an code owners as-is when the team map is empty", () => {
-    expect(convert(lCodeOwners, {})).to.deep.equal(lCodeOwners);
+    equal(convert(lCodeOwners, {}), lCodeOwners);
   });
 
   it("replaces team names with usernames as specified in the team map", () => {
@@ -27,7 +26,7 @@ libs/after-sales @team-after-sales
 
 # tooling maintained by a rag tag band of 20% friday afternooners
 tools/ @team-tgif`;
-    expect(convert(lCodeOwners, lTeamMap)).to.equal(lExpected);
+    equal(convert(lCodeOwners, lTeamMap), lExpected);
   });
 
   it("replaces team names when there's > 1 team on the line", () => {
@@ -37,7 +36,7 @@ tools/ @team-tgif`;
       "team-after-sales": ["wim", "zus", "jet"],
     };
     const lExpected = "tools/shared @jan @pier @tjorus @wim @zus @jet";
-    expect(convert(lFixture, lTeamMapFixture)).to.equal(lExpected);
+    equal(convert(lFixture, lTeamMapFixture), lExpected);
   });
 
   it.skip("replaces team names & deduplicates usernames when there's > 1 team on the line => doesn't seem necessary; repeating usernames seem OK", () => {
@@ -47,6 +46,6 @@ tools/ @team-tgif`;
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
     const lExpected = "tools/shared @jan @multi-teamer @tjorus @wim @zus @jet";
-    expect(convert(lFixture, lTeamMapFixture)).to.equal(lExpected);
+    equal(convert(lFixture, lTeamMapFixture), lExpected);
   });
 });

--- a/src/read-and-convert.spec.ts
+++ b/src/read-and-convert.spec.ts
@@ -1,19 +1,18 @@
+import { equal } from "node:assert";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
-import { expect } from "chai";
 import { readAndCovert } from "./read-and-convert.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("reads and converts", () => {
   it("returns a CODEOWNERS as a string when passed file names of valid virtual code owners & virtual teams", () => {
-    expect(
+    equal(
       readAndCovert(
         join(__dirname, "__mocks__", "VIRTUAL-CODEOWNERS.txt"),
         join(__dirname, "__mocks__", "virtual-teams.yml")
-      )
-    ).to.equal(
+      ),
       readFileSync(join(__dirname, "__fixtures__", "CODEOWNERS"), {
         encoding: "utf-8",
       })


### PR DESCRIPTION
## Description, Motivation and Context

Replaces chai expect/ assertion library with functions from node:assert, which ships with the node platform anyway. This way there's less external dependencies and less to maintain/ keep up to date.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
