### PR TITLE
feat: adds a 'this file was generated' warning at the top of the generated CODE-OWNERS file

### DIFF
--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -1,4 +1,12 @@
 import { EOL } from "node:os";
+const DEFAULT_GENERATED_WARNING = `#${EOL}` +
+    `# DO NOT EDIT - this file is generated and your edits will be overwritten${EOL}` +
+    `#${EOL}` +
+    `# To make changes:${EOL}` +
+    `#${EOL}` +
+    `#   - edit VIRTUAL-CODEOWNERS.txt${EOL}` +
+    `#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'${EOL}` +
+    `#${EOL}${EOL}`;
 function replaceTeamNames(pLine, pTeamMap) {
     let lReturnValue = pLine;
     for (let lTeamName of Object.keys(pTeamMap)) {
@@ -17,9 +25,9 @@ function convertLine(pTeamMap) {
         }
     };
 }
-export function convert(pCodeOwnersFileAsString, pTeamMap) {
-    return pCodeOwnersFileAsString
+export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_GENERATED_WARNING) {
+    return `${pGeneratedWarning}${pCodeOwnersFileAsString
         .split(EOL)
         .map(convertLine(pTeamMap))
-        .join(EOL);
+        .join(EOL)}`;
 }

--- a/src/__fixtures__/CODEOWNERS
+++ b/src/__fixtures__/CODEOWNERS
@@ -1,3 +1,12 @@
+#
+# DO NOT EDIT - this file is generated and your edits will be overwritten
+#
+# To make changes:
+#
+#   - edit VIRTUAL-CODEOWNERS.txt
+#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'
+#
+
 # catch-all to ensure there at least _is_ a code owner, even when
 # it's _everyone_
 

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -1,6 +1,8 @@
 import { equal } from "node:assert";
+import { EOL } from "node:os";
 import { convert, ITeamMap } from "./convert-virtual-code-owners.js";
-describe("doSomething does something", () => {
+
+describe("convert-virtual-code-owners converts", () => {
   const lCodeOwners = `# here's a comment
 * @everyone
 # regular functionality
@@ -11,7 +13,7 @@ libs/after-sales @team-after-sales
 tools/ @team-tgif`;
 
   it("leaves an code owners as-is when the team map is empty", () => {
-    equal(convert(lCodeOwners, {}), lCodeOwners);
+    equal(convert(lCodeOwners, {}, ""), lCodeOwners);
   });
 
   it("replaces team names with usernames as specified in the team map", () => {
@@ -26,7 +28,7 @@ libs/after-sales @team-after-sales
 
 # tooling maintained by a rag tag band of 20% friday afternooners
 tools/ @team-tgif`;
-    equal(convert(lCodeOwners, lTeamMap), lExpected);
+    equal(convert(lCodeOwners, lTeamMap, ""), lExpected);
   });
 
   it("replaces team names when there's > 1 team on the line", () => {
@@ -36,7 +38,7 @@ tools/ @team-tgif`;
       "team-after-sales": ["wim", "zus", "jet"],
     };
     const lExpected = "tools/shared @jan @pier @tjorus @wim @zus @jet";
-    equal(convert(lFixture, lTeamMapFixture), lExpected);
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
   it.skip("replaces team names & deduplicates usernames when there's > 1 team on the line => doesn't seem necessary; repeating usernames seem OK", () => {
@@ -46,6 +48,15 @@ tools/ @team-tgif`;
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
     const lExpected = "tools/shared @jan @multi-teamer @tjorus @wim @zus @jet";
-    equal(convert(lFixture, lTeamMapFixture), lExpected);
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
+  });
+
+  it("adds a warning text on top when passed one", () => {
+    const lFixture = "tools/shared @team-sales @team-after-sales";
+    const lTeamMapFixture = {};
+    const lWarningText = `# warning - generated, do not edit${EOL}`;
+    const lExpected = `${lWarningText}${lFixture}`;
+
+    equal(convert(lFixture, lTeamMapFixture, lWarningText), lExpected);
   });
 });

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -4,6 +4,16 @@ export interface ITeamMap {
   [teamName: string]: string[];
 }
 
+const DEFAULT_GENERATED_WARNING =
+  `#${EOL}` +
+  `# DO NOT EDIT - this file is generated and your edits will be overwritten${EOL}` +
+  `#${EOL}` +
+  `# To make changes:${EOL}` +
+  `#${EOL}` +
+  `#   - edit VIRTUAL-CODEOWNERS.txt${EOL}` +
+  `#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'${EOL}` +
+  `#${EOL}${EOL}`;
+
 function replaceTeamNames(pLine: string, pTeamMap: ITeamMap) {
   let lReturnValue = pLine;
 
@@ -33,10 +43,11 @@ function convertLine(pTeamMap: ITeamMap) {
 
 export function convert(
   pCodeOwnersFileAsString: string,
-  pTeamMap: ITeamMap
+  pTeamMap: ITeamMap,
+  pGeneratedWarning: string = DEFAULT_GENERATED_WARNING
 ): string {
-  return pCodeOwnersFileAsString
+  return `${pGeneratedWarning}${pCodeOwnersFileAsString
     .split(EOL)
     .map(convertLine(pTeamMap))
-    .join(EOL);
+    .join(EOL)}`;
 }


### PR DESCRIPTION
## Description

- adds a 'this file was generated' warning at the top of the generated CODE-OWNERS file

## Motivation and Context

Prevents mishaps because you inadvertently edit the generated CODE-OWNERS file.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
