### PR TITLE
feat: adds ignorable comments to input format

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,4 +1,5 @@
 {
+  "checkCoverage": true,
   "statements": 100,
   "branches": 100,
   "functions": 100,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run depcruise
-      - run: npm run test:cover
+      - run: npm test
       - name: emit coverage results to step summary
         if: always() && matrix.node-version == env.NODE_LATEST
         run: |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ the _teams_ the former uses might not exist yet, except in a `virtual-teams.yml`
 Example:
 
 ```
+#! comments that start with #! won't appear in the CODEOWNERS output e.g.
+#! this is not the CODEOWNERS file - to get that one run
+#!   npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS
+#! on this.
+#!
+# Regular comments are retained
 * @cloud-heroes-all
 .github/ @ch/transversal
 apps/broker @ch/transversal

--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -25,9 +25,13 @@ function convertLine(pTeamMap) {
         }
     };
 }
+function isNotIgnorable(pLine) {
+    return !pLine.trimStart().startsWith("#!");
+}
 export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_GENERATED_WARNING) {
     return `${pGeneratedWarning}${pCodeOwnersFileAsString
         .split(EOL)
+        .filter(isNotIgnorable)
         .map(convertLine(pTeamMap))
         .join(EOL)}`;
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && node tools/get-version.mjs > src/version.ts && tsc",
+    "check": "npm run format && npm run build && npm run depcruise -- --no-progress && npm test",
     "depcruise": "depcruise src --config .dependency-cruiser.cjs",
     "depcruise:graph": "depcruise src --include-only '^(src)' --config --output-type dot | dot -T svg | depcruise-wrap-stream-in-html > dependency-graph.html",
     "depcruise:graph:dev": "depcruise src --prefix vscode://file/$(pwd)/ --config --output-type dot | dot -T svg | depcruise-wrap-stream-in-html | browser",
@@ -28,9 +29,8 @@
     "depcruise:html": "depcruise src --config --output-type err-html --output-to dependency-violation-report.html",
     "format": "prettier --loglevel warn --write \"**/*.{md,ts,json,yml}\"",
     "scm:stage": "git add .",
-    "test": "NODE_OPTIONS=--no-warnings mocha",
-    "test:cover": "NODE_OPTIONS=--no-warnings c8 mocha",
-    "update-dependencies": "npm run upem:update && npm run upem:install && npm run format && npm run build && npm test",
+    "test": "NODE_OPTIONS=--no-warnings c8 mocha",
+    "update-dependencies": "npm run upem:update && npm run upem:install && npm run check",
     "upem-outdated": "npm outdated --json --long | upem --dry-run",
     "upem:install": "npm install",
     "upem:update": "npm outdated --json --long | upem | pbcopy && pbpaste",
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.5",
+    "@types/mocha": "10.0.1",
     "@types/node": "18.14.5",
     "c8": "7.13.0",
     "dependency-cruiser": "12.10.0",

--- a/src/__fixtures__/CODEOWNERS
+++ b/src/__fixtures__/CODEOWNERS
@@ -27,7 +27,3 @@ libs/components/ @davy-davidson-ch @john-johnson-ch @joe-dalton-ch
 libs/ubc-sales/ @gregory-gregson-ch @jane-doe-ch
 libs/ubc-after-sales/ @john-doe-ch @pete-peterson-ch @william-the-fourth-ch
 libs/ubc-pre-sales/ @jean-claude-ch @valerie-valerton-ch @averel-dalton-ch
-
-# The VIRTUAL-CODEOWNERS.txt file has the .txt extension because untamed vscode
-# installations might otherwise interpret it as markdown and auto-correct
-# and auto-format it as such

--- a/src/__mocks__/VIRTUAL-CODEOWNERS.txt
+++ b/src/__mocks__/VIRTUAL-CODEOWNERS.txt
@@ -1,3 +1,7 @@
+#! this is not the CODEOWNERS file - to get that one run
+#!   npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS
+#! on this.
+#!
 # catch-all to ensure there at least _is_ a code owner, even when
 # it's _everyone_
 
@@ -18,7 +22,7 @@ libs/components/ @ch/ux
 libs/ubc-sales/ @ch/sales
 libs/ubc-after-sales/ @ch/after-sales
 libs/ubc-pre-sales/ @ch/pre-sales
-
-# The VIRTUAL-CODEOWNERS.txt file has the .txt extension because untamed vscode
-# installations might otherwise interpret it as markdown and auto-correct
-# and auto-format it as such
+#!
+#! The VIRTUAL-CODEOWNERS.txt file has the .txt extension because untamed vscode
+#! installations might otherwise interpret it as markdown and auto-correct
+#! and auto-format it as such

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -51,6 +51,12 @@ tools/ @team-tgif`;
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
+  it("skips lines that start with '#!'", () => {
+    const lFixture = `#!ignore this line${EOL}    #! and this as well${EOL}# but not this one${EOL}and/neither @this-one`;
+    const lExpected = `# but not this one${EOL}and/neither @this-one`;
+    equal(convert(lFixture, {}, ""), lExpected);
+  });
+
   it("adds a warning text on top when passed one", () => {
     const lFixture = "tools/shared @team-sales @team-after-sales";
     const lTeamMapFixture = {};

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -41,6 +41,17 @@ function convertLine(pTeamMap: ITeamMap) {
   };
 }
 
+function isNotIgnorable(pLine: string): boolean {
+  // You can mark comments that aren't relevant to appear in the result with
+  // a #! token.
+  //
+  // #! this is not the CODEOWNERS file - to get that one run
+  // #!   npx convert-code-owner  thisfile.txt virtual-teams.yml > CODEOWNERS
+  // #! on this.
+  //
+  return !pLine.trimStart().startsWith("#!");
+}
+
 export function convert(
   pCodeOwnersFileAsString: string,
   pTeamMap: ITeamMap,
@@ -48,6 +59,7 @@ export function convert(
 ): string {
   return `${pGeneratedWarning}${pCodeOwnersFileAsString
     .split(EOL)
+    .filter(isNotIgnorable)
     .map(convertLine(pTeamMap))
     .join(EOL)}`;
 }


### PR DESCRIPTION
## Description

- Ignore lines staring with `#!` in the input VIRTUAL-CODE-OWNERS.txt
- 🏕️ : combines lint, format, test into one `check` run script
- 🏕️ : removes the `test:cover` run script and makes the `test` run script check coverage (code base is small enough that the overhead doesn't matter)
- 🏕️ : make c8 fail when code coverage is < 100%
- 🏕️ : adds @types/mocha as a devDependency so there's no squigly lines under `describe` and `it` in spec files anymore.

## Motivation and Context

You might want to make comments that shouldn't appear in the CODEOWNERS file, e.g. instructions how to use the VIRTUAL-CODE-OWNERS.txt.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test & integration test
- [x] manual runs

## Example

```
#! this is not the CODEOWNERS file - to get that one run
#!   npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS
#! on this.
#!
#! note: lines that start with #! don't appear in the CODEOWNERS output
#!
# catch-all to ensure there at least _is_ a code owner, even when
# it's _everyone_

* @cloud-heroes-all

# admin & ci shizzle => transversal

.github/ @ch/transversal

# generic stuff

apps/framework @ch/transversal
apps/ux-portal/ @ch/ux @ch/transversal
libs/components/ @ch/ux

# specific functionality

libs/ubc-sales/ @ch/sales
libs/ubc-after-sales/ @ch/after-sales
libs/ubc-pre-sales/ @ch/pre-sales

#! The VIRTUAL-CODEOWNERS.txt file has the .txt extension because untamed vscode
#! installations might otherwise interpret it as markdown and auto-correct
#! and auto-format it as such
```

will output:
```
#
# DO NOT EDIT - this file is generated and your edits will be overwritten
#
# To make changes:
#
#   - edit VIRTUAL-CODEOWNERS.txt
#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'
#

# catch-all to ensure there at least _is_ a code owner, even when
# it's _everyone_

* @cloud-heroes-all

# admin & ci shizzle => transversal

.github/ @luke-the-lucky-ch

# generic stuff

apps/framework @luke-the-lucky-ch
apps/ux-portal/ @davy-davidson-ch @john-johnson-ch @joe-dalton-ch @luke-the-lucky-ch
libs/components/ @davy-davidson-ch @john-johnson-ch @joe-dalton-ch

# specific functionality

libs/ubc-sales/ @gregory-gregson-ch @jane-doe-ch
libs/ubc-after-sales/ @john-doe-ch @pete-peterson-ch @william-the-fourth-ch
libs/ubc-pre-sales/ @jean-claude-ch @valerie-valerton-ch @averel-dalton-ch


```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
