### PR TITLE
feature: adds support for running without arguments BREAKING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+#
+# DO NOT EDIT - this file is generated and your edits will be overwritten
+#
+# To make changes:
+#
+#   - edit .github/VIRTUAL-CODEOWNERS.txt
+#   - run 'npx virtual-code-owners'
+#
+
+# catch-all to ensure there at least _is_ a code owner
+* @sverweij
+
+# For things in .github also the eye of the admin group is useful
+.github/ @sverweij @mcmeadow

--- a/.github/VIRTUAL-CODEOWNERS.txt
+++ b/.github/VIRTUAL-CODEOWNERS.txt
@@ -1,0 +1,8 @@
+#! this is not the CODEOWNERS file - to get that one run
+#!   npx virtual-code-owners
+#!
+# catch-all to ensure there at least _is_ a code owner
+* @vco-maintainers
+
+# For things in .github also the eye of the admin group is useful
+.github/ @vco-admins

--- a/.github/virtual-teams.yml
+++ b/.github/virtual-teams.yml
@@ -1,0 +1,5 @@
+vco-admins:
+  - sverweij
+  - mcmeadow
+vco-maintainers:
+  - sverweij

--- a/README.md
+++ b/README.md
@@ -5,16 +5,25 @@ This takes a
 - VIRTUAL-CODEOWNERS.txt file with (virtual) teams
 - a `virtual-teams.yml` file which define the teams
 
-... and churns out a CODEOWNERS with user names.
+... and merges them into a CODEOWNERS with user names.
 
 ## Usage
 
-- Rename your `CODEOWNERS` to `VIRTUAL-CODEOWNERS.txt` and put team names in them.
-- Specify team names that don't (yet) exist on GitHub level in a `virtual-teams.yml`
+- Rename your `.github/CODEOWNERS` to `.github/VIRTUAL-CODEOWNERS.txt` and put team names in them.
+- Specify team names that don't (yet) exist on GitHub level in a `.github/virtual-teams.yml`
 - Run this:
 
 ```
-npx virtual-code-owners VIRTUAL-CODEOWNERS.txt virtual-teams.yml > .github/CODEOWNERS
+npx virtual-code-owners
+```
+
+or, if you want to be verbose
+
+```
+npx virtual-code-owners \
+  --virtual-code-owners .github/VIRTUAL-CODEOWNERS.txt \
+  --virtual-teams .github/virtual-teams.yml \
+  --code-owners .github/CODEOWNERS
 ```
 
 ## Why?
@@ -94,7 +103,7 @@ It might be you already have a team or two defined, but just want to use
 _additional_ teams. In that case just don't specify the already-defined teams
 in `virtual-teams.yml` and _virtual-code-owners_ will leave them alone.
 
-### Can I still use usernames in `VIRTUAL-CODEOWNERS.txt`
+### Can I still use usernames in `VIRTUAL-CODEOWNERS.txt`?
 
 Yes.
 
@@ -123,3 +132,18 @@ present on text files.
 
 Apparently these editors know about CODEOWNERS, though so this auto formatting
 doesn't seem to be happening over there.
+
+### Do I have to run this each time I edit `VIRTUAL-CODEOWNERS.txt`?
+
+Yes. But please automate this for your own sake.
+
+You can for instance set up a rule for `lint-staged` in a `.lintstagedrc.json`
+like this:
+
+```json
+{
+  ".github/VIRTUAL-CODEOWNERS.txt|.github/virtual-teams.yml": [
+    "npx virtual-code-owners"
+  ]
+}
+```

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2,14 +2,23 @@
 import { program } from "commander";
 import { VERSION } from "./version.js";
 import { readAndConvert } from "./read-and-convert.js";
+import { writeFileSync } from "node:fs";
+import { EOL } from "node:os";
 program
-    .description("Takes a VIRTUAL-CODEOWNERS.txt & a virtual-teams.yml and emits a CODEOWNERS to stdout")
+    .description("Merges a VIRTUAL-CODEOWNERS.txt and a virtual-teams.yml into CODEOWNERS")
     .version(VERSION)
-    .arguments("<virtual-code-owners-file> <virtual-teams.yml>")
+    .option("-v, --virtual-code-owners [file-name]", "A CODEOWNERS file with team names in them that are defined in a virtual teams file", ".github/VIRTUAL-CODEOWNERS.txt")
+    .option("-t, --virtual-teams [file-name]", "A YAML file listing teams and their members", ".github/virtual-teams.yml")
+    .option("-c, --code-owners [file-name]", "The location of the CODEOWNERS file", ".github/CODEOWNERS")
     .parse(process.argv);
 try {
-    console.log(readAndConvert(program.args[0], program.args[1]));
+    const lCodeOwnersContent = readAndConvert(program.opts().virtualCodeOwners, program.opts().virtualTeams);
+    writeFileSync(program.opts().codeOwners, lCodeOwnersContent, {
+        encoding: "utf-8",
+    });
+    console.error(`${EOL}Wrote ${program.opts().codeOwners}${EOL}`);
 }
 catch (pError) {
     console.error(`ERROR: ${pError.message}`);
+    process.exitCode = 1;
 }

--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -4,8 +4,8 @@ const DEFAULT_GENERATED_WARNING = `#${EOL}` +
     `#${EOL}` +
     `# To make changes:${EOL}` +
     `#${EOL}` +
-    `#   - edit VIRTUAL-CODEOWNERS.txt${EOL}` +
-    `#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'${EOL}` +
+    `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
+    `#   - run 'npx virtual-code-owners'${EOL}` +
     `#${EOL}${EOL}`;
 function replaceTeamNames(pLine, pTeamMap) {
     let lReturnValue = pLine;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "virtual-code-owners",
   "version": "1.0.0",
-  "description": "merges a VIRTUAL-CODEOWNERS.txt and a virtual-teams.yml into CODEOWNERS",
+  "description": "Merges a VIRTUAL-CODEOWNERS.txt and a virtual-teams.yml into CODEOWNERS",
   "type": "module",
   "exports": {
     ".": [

--- a/src/__fixtures__/CODEOWNERS
+++ b/src/__fixtures__/CODEOWNERS
@@ -3,8 +3,8 @@
 #
 # To make changes:
 #
-#   - edit VIRTUAL-CODEOWNERS.txt
-#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'
+#   - edit .github/VIRTUAL-CODEOWNERS.txt
+#   - run 'npx virtual-code-owners'
 #
 
 # catch-all to ensure there at least _is_ a code owner, even when

--- a/src/__mocks__/VIRTUAL-CODEOWNERS.txt
+++ b/src/__mocks__/VIRTUAL-CODEOWNERS.txt
@@ -1,6 +1,5 @@
 #! this is not the CODEOWNERS file - to get that one run
-#!   npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS
-#! on this.
+#!   npx virtual-code-owners
 #!
 # catch-all to ensure there at least _is_ a code owner, even when
 # it's _everyone_

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,19 +1,42 @@
 #!/usr/bin/env node
-
 import { program } from "commander";
 import { VERSION } from "./version.js";
 import { readAndConvert } from "./read-and-convert.js";
+import { writeFileSync } from "node:fs";
+import { EOL } from "node:os";
 
 program
   .description(
-    "Takes a VIRTUAL-CODEOWNERS.txt & a virtual-teams.yml and emits a CODEOWNERS to stdout"
+    "Merges a VIRTUAL-CODEOWNERS.txt and a virtual-teams.yml into CODEOWNERS"
   )
   .version(VERSION)
-  .arguments("<virtual-code-owners-file> <virtual-teams.yml>")
+  .option(
+    "-v, --virtual-code-owners [file-name]",
+    "A CODEOWNERS file with team names in them that are defined in a virtual teams file",
+    ".github/VIRTUAL-CODEOWNERS.txt"
+  )
+  .option(
+    "-t, --virtual-teams [file-name]",
+    "A YAML file listing teams and their members",
+    ".github/virtual-teams.yml"
+  )
+  .option(
+    "-c, --code-owners [file-name]",
+    "The location of the CODEOWNERS file",
+    ".github/CODEOWNERS"
+  )
   .parse(process.argv);
 
 try {
-  console.log(readAndConvert(program.args[0], program.args[1]));
+  const lCodeOwnersContent = readAndConvert(
+    program.opts().virtualCodeOwners,
+    program.opts().virtualTeams
+  );
+  writeFileSync(program.opts().codeOwners, lCodeOwnersContent, {
+    encoding: "utf-8",
+  });
+  console.error(`${EOL}Wrote ${program.opts().codeOwners}${EOL}`);
 } catch (pError: any) {
   console.error(`ERROR: ${pError.message}`);
+  process.exitCode = 1;
 }

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -10,8 +10,8 @@ const DEFAULT_GENERATED_WARNING =
   `#${EOL}` +
   `# To make changes:${EOL}` +
   `#${EOL}` +
-  `#   - edit VIRTUAL-CODEOWNERS.txt${EOL}` +
-  `#   - run 'npx virtual-code-owners VIRTUAL-CODE-OWNERS.txt virtual-teams.yml > CODEOWNERS'${EOL}` +
+  `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
+  `#   - run 'npx virtual-code-owners'${EOL}` +
   `#${EOL}${EOL}`;
 
 function replaceTeamNames(pLine: string, pTeamMap: ITeamMap) {


### PR DESCRIPTION
## Description

- replaces positional arguments with options
- adds defaults to the options that should cover 99.9% of the use cases
- removes the posibility to write the output to stdout
- sets process exit to 1 if something went awry (in addition to logging something to stderr)
- dog foods the solution

## Motivation and Context

Easier to use in e.g. lint-staged, and less chance for errors.

## How Has This Been Tested?

- [x] green ci
- [x] some manual checks (in a .lintstagedrc)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
