### PR TITLE
fix: makes replacement respect word boundaries

### DIFF
--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -41,6 +41,16 @@ tools/ @team-tgif`;
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
+  it("correctly replaces a team name that is a substring of another one", () => {
+    const lFixture = "tools/shared @substring";
+    const lTeamMapFixture = {
+      sub: ["jan", "pier", "tjorus"],
+      substring: ["wim", "zus", "jet"],
+    };
+    const lExpected = "tools/shared @wim @zus @jet";
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
+  });
+
   it.skip("replaces team names & deduplicates usernames when there's > 1 team on the line => doesn't seem necessary; repeating usernames seem OK", () => {
     const lFixture = "tools/shared @team-sales @team-after-sales";
     const lTeamMapFixture = {

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -19,8 +19,8 @@ function replaceTeamNames(pLine: string, pTeamMap: ITeamMap) {
 
   for (let lTeamName of Object.keys(pTeamMap)) {
     lReturnValue = lReturnValue.replace(
-      `@${lTeamName}`,
-      pTeamMap[lTeamName].map((pUserName) => `@${pUserName}`).join(" ")
+      new RegExp(`(\\s)@${lTeamName}(\\s|$)`, "g"),
+      `$1${pTeamMap[lTeamName].map((pUserName) => `@${pUserName}`).join(" ")}$2`
     );
   }
 


### PR DESCRIPTION
## Description, motivation and context

- makes the replacement respect word boundaries, so overlapping team names (@team-sub, @team-substring) don't get confused.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
