### PR TITLE
feat: de-duplicates usernames

### DIFF
--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -25,13 +25,22 @@ function convertLine(pTeamMap) {
         }
     };
 }
-function isNotIgnorable(pLine) {
+function deduplicateUserNames(pLine) {
+    const lTrimmedLine = pLine.trim();
+    const lSplitLine = lTrimmedLine.match(/^(?<filesPattern>[^\s]+)(?<theRest>.*)$/);
+    if (lTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
+        return pLine;
+    }
+    return `${lSplitLine.groups.filesPattern} ${Array.from(new Set(lSplitLine.groups.theRest.trim().split(/\s+/))).join(" ")}`;
+}
+function shouldAppearInResult(pLine) {
     return !pLine.trimStart().startsWith("#!");
 }
 export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_GENERATED_WARNING) {
     return `${pGeneratedWarning}${pCodeOwnersFileAsString
         .split(EOL)
-        .filter(isNotIgnorable)
+        .filter(shouldAppearInResult)
         .map(convertLine(pTeamMap))
+        .map(deduplicateUserNames)
         .join(EOL)}`;
 }

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -51,8 +51,8 @@ tools/ @team-tgif`;
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
-  it.skip("replaces team names & deduplicates usernames when there's > 1 team on the line => doesn't seem necessary; repeating usernames seem OK", () => {
-    const lFixture = "tools/shared @team-sales @team-after-sales";
+  it("replaces team names & deduplicates usernames when there's > 1 team on the line", () => {
+    const lFixture = "tools/shared  @team-sales @team-after-sales             ";
     const lTeamMapFixture = {
       "team-sales": ["jan", "multi-teamer", "tjorus"],
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],


### PR DESCRIPTION
## Description

- de-duplicates usernames in the resulting CODEOWNERS file

## Motivation and Context

OCD

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Example

```
#! VIRTUAL-CODEOWNERS.txt

.github team-a
src/simple-stuff team-a team-b
src/difficult-stuff team-b
```

```yaml
# virtual-teams.yml
team-a:
  - jan
  - uitslover
  - piet
team-b:
  - klaas
  - uitslover
  - marie
```

```
# CODEOWNERS

.github @jan @uitslover @piet
src/simple-stuff @jan @uitslover @piet @klaas @marie
src/difficult-stuff @klaas @uitslover @marie
```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
