### PR TITLE
refactor: splits off inline function

### DIFF
--- a/.github/virtual-teams.yml
+++ b/.github/virtual-teams.yml
@@ -4,4 +4,3 @@ vco:
 vco-admins:
   - sverweij
   - mcmeadow
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ES2022" /* Specify what module code is generated. */,
     "rootDir": "./src/" /* Specify the root folder within your source files. */,
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Description

- splits off inline function
- reorders function calls in convert-virtual-code-owners top down
- sets moduleResolution in  tsconfig to nodenext

## Motivation and Context

- readability

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
