### PR TITLE
refactor: makes parsing more robust & leave some of the spaces in place

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 #
 
 # catch-all to ensure there at least _is_ a code owner
-* @sverweij
+*        @sverweij
 
 # For things in .github also the eye of the admin group is useful
 .github/ @sverweij @mcmeadow

--- a/.github/VIRTUAL-CODEOWNERS.txt
+++ b/.github/VIRTUAL-CODEOWNERS.txt
@@ -2,7 +2,7 @@
 #!   npx virtual-code-owners
 #!
 # catch-all to ensure there at least _is_ a code owner
-* @vco
+*        @vco
 
 # For things in .github also the eye of the admin group is useful
 .github/ @vco-admins

--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -7,6 +7,7 @@ const DEFAULT_GENERATED_WARNING = `#${EOL}` +
     `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
     `#   - run 'npx virtual-code-owners'${EOL}` +
     `#${EOL}${EOL}`;
+const LINE_PATTERN = /^(?<filesPattern>[^\s]+\s+)(?<userNames>.*)$/;
 export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_GENERATED_WARNING) {
     return `${pGeneratedWarning}${pCodeOwnersFileAsString
         .split(EOL)
@@ -25,25 +26,28 @@ function convertLine(pTeamMap) {
             return pUntreatedLine;
         }
         else {
-            return replaceTeamNames(pUntreatedLine, pTeamMap);
+            return replaceTeamNames(lTrimmedLine, pTeamMap);
         }
     };
 }
-function replaceTeamNames(pLine, pTeamMap) {
-    let lReturnValue = pLine;
-    for (let lTeamName of Object.keys(pTeamMap)) {
-        lReturnValue = lReturnValue.replace(new RegExp(`(\\s)@${lTeamName}(\\s|$)`, "g"), `$1${stringifyTeamMembers(pTeamMap, lTeamName)}$2`);
+function replaceTeamNames(pTrimmedLine, pTeamMap) {
+    const lSplitLine = pTrimmedLine.match(LINE_PATTERN);
+    if (!lSplitLine?.groups) {
+        return pTrimmedLine;
     }
-    return lReturnValue;
+    let lUserNames = lSplitLine.groups.userNames.trim();
+    for (let lTeamName of Object.keys(pTeamMap)) {
+        lUserNames = lUserNames.replace(new RegExp(`(\\s|^)@${lTeamName}(\\s|$)`, "g"), `$1${stringifyTeamMembers(pTeamMap, lTeamName)}$2`);
+    }
+    return `${lSplitLine.groups.filesPattern}${lUserNames}`;
 }
 function stringifyTeamMembers(pTeamMap, pTeamName) {
     return pTeamMap[pTeamName].map((pUserName) => `@${pUserName}`).join(" ");
 }
-function deduplicateUserNames(pLine) {
-    const lTrimmedLine = pLine.trim();
-    const lSplitLine = lTrimmedLine.match(/^(?<filesPattern>[^\s]+)(?<theRest>.*)$/);
-    if (lTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
-        return pLine;
+function deduplicateUserNames(pTrimmedLine) {
+    const lSplitLine = pTrimmedLine.match(LINE_PATTERN);
+    if (pTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
+        return pTrimmedLine;
     }
-    return `${lSplitLine.groups.filesPattern} ${Array.from(new Set(lSplitLine.groups.theRest.trim().split(/\s+/))).join(" ")}`;
+    return `${lSplitLine.groups.filesPattern}${Array.from(new Set(lSplitLine.groups.userNames.trim().split(/\s+/))).join(" ")}`;
 }

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -52,12 +52,44 @@ tools/ @team-tgif`;
   });
 
   it("replaces team names & deduplicates usernames when there's > 1 team on the line", () => {
-    const lFixture = "tools/shared  @team-sales @team-after-sales             ";
+    const lFixture = "tools/shared @team-sales @team-after-sales             ";
     const lTeamMapFixture = {
       "team-sales": ["jan", "multi-teamer", "tjorus"],
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
     const lExpected = "tools/shared @jan @multi-teamer @tjorus @wim @zus @jet";
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
+  });
+
+  it("does not replace file names that happen to be a team name as well", () => {
+    const lFixture = "@team-sales @team-after-sales";
+    const lTeamMapFixture = {
+      "team-sales": ["jan", "multi-teamer", "tjorus"],
+      "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
+    };
+    const lExpected = "@team-sales @multi-teamer @wim @zus @jet";
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
+  });
+
+  it("retains spaces between filenames and user names", () => {
+    const lFixture =
+      "tools/shared     @team-sales @team-after-sales             ";
+    const lTeamMapFixture = {
+      "team-sales": ["jan", "multi-teamer", "tjorus"],
+      "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
+    };
+    const lExpected =
+      "tools/shared     @jan @multi-teamer @tjorus @wim @zus @jet";
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
+  });
+
+  it("leaves lines that don't have the filesPattern & usernames pattern alone", () => {
+    const lFixture = "tools/shared";
+    const lTeamMapFixture = {
+      "team-sales": ["jan", "multi-teamer", "tjorus"],
+      "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
+    };
+    const lExpected = "tools/shared";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 


### PR DESCRIPTION
## Description

- now only executes the replace on the usernames part of the string
- leaves spaces between the file name pattern and the usernames in 

## Motivation and Context

This was working correctly before, but only because the file name pattern happens to be at the dead start of the string. This is implicit and can lead to subtle bugs. This refactor makes
it explicit.

The _leaves spaces_ one is for those of us who suffer from OCD.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
