### PR TITLE
feature: sorts usernames

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
-name: 'CodeQL config'
+name: "CodeQL config"
 
 paths:
   - src/

--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -50,5 +50,7 @@ function deduplicateUserNames(pTrimmedLine) {
     if (pTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
         return pTrimmedLine;
     }
-    return `${lSplitLine.groups.filesPattern}${Array.from(new Set(lSplitLine.groups.userNames.trim().split(/\s+/))).join(" ")}`;
+    return `${lSplitLine.groups.filesPattern}${Array.from(new Set(lSplitLine.groups.userNames.trim().split(/\s+/)))
+        .sort()
+        .join(" ")}`;
 }

--- a/src/__fixtures__/CODEOWNERS
+++ b/src/__fixtures__/CODEOWNERS
@@ -20,11 +20,11 @@
 # generic stuff
 
 apps/framework @luke-the-lucky-ch
-apps/ux-portal/ @davy-davidson-ch @john-johnson-ch @joe-dalton-ch @luke-the-lucky-ch
-libs/components/ @davy-davidson-ch @john-johnson-ch @joe-dalton-ch
+apps/ux-portal/ @davy-davidson-ch @joe-dalton-ch @john-johnson-ch @luke-the-lucky-ch
+libs/components/ @davy-davidson-ch @joe-dalton-ch @john-johnson-ch
 
 # specific functionality
 
 libs/ubc-sales/ @gregory-gregson-ch @jane-doe-ch
 libs/ubc-after-sales/ @john-doe-ch @pete-peterson-ch @william-the-fourth-ch
-libs/ubc-pre-sales/ @jean-claude-ch @valerie-valerton-ch @averel-dalton-ch
+libs/ubc-pre-sales/ @averel-dalton-ch @jean-claude-ch @valerie-valerton-ch

--- a/src/convert-virtual-code-owners.spec.ts
+++ b/src/convert-virtual-code-owners.spec.ts
@@ -23,7 +23,7 @@ tools/ @team-tgif`;
     const lExpected = `# here's a comment
 * @everyone
 # regular functionality
-libs/sales @jan @pier @tjorus @korneel @the-cat
+libs/sales @jan @korneel @pier @the-cat @tjorus
 libs/after-sales @team-after-sales
 
 # tooling maintained by a rag tag band of 20% friday afternooners
@@ -37,7 +37,7 @@ tools/ @team-tgif`;
       "team-sales": ["jan", "pier", "tjorus"],
       "team-after-sales": ["wim", "zus", "jet"],
     };
-    const lExpected = "tools/shared @jan @pier @tjorus @wim @zus @jet";
+    const lExpected = "tools/shared @jan @jet @pier @tjorus @wim @zus";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
@@ -47,7 +47,7 @@ tools/ @team-tgif`;
       sub: ["jan", "pier", "tjorus"],
       substring: ["wim", "zus", "jet"],
     };
-    const lExpected = "tools/shared @wim @zus @jet";
+    const lExpected = "tools/shared @jet @wim @zus";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
@@ -57,7 +57,7 @@ tools/ @team-tgif`;
       "team-sales": ["jan", "multi-teamer", "tjorus"],
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
-    const lExpected = "tools/shared @jan @multi-teamer @tjorus @wim @zus @jet";
+    const lExpected = "tools/shared @jan @jet @multi-teamer @tjorus @wim @zus";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
@@ -67,7 +67,7 @@ tools/ @team-tgif`;
       "team-sales": ["jan", "multi-teamer", "tjorus"],
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
-    const lExpected = "@team-sales @multi-teamer @wim @zus @jet";
+    const lExpected = "@team-sales @jet @multi-teamer @wim @zus";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
@@ -79,7 +79,7 @@ tools/ @team-tgif`;
       "team-after-sales": ["multi-teamer", "wim", "zus", "jet"],
     };
     const lExpected =
-      "tools/shared     @jan @multi-teamer @tjorus @wim @zus @jet";
+      "tools/shared     @jan @jet @multi-teamer @tjorus @wim @zus";
     equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 
@@ -100,11 +100,19 @@ tools/ @team-tgif`;
   });
 
   it("adds a warning text on top when passed one", () => {
-    const lFixture = "tools/shared @team-sales @team-after-sales";
+    const lFixture = "tools/shared @team-after-sales @team-sales";
     const lTeamMapFixture = {};
     const lWarningText = `# warning - generated, do not edit${EOL}`;
     const lExpected = `${lWarningText}${lFixture}`;
 
     equal(convert(lFixture, lTeamMapFixture, lWarningText), lExpected);
+  });
+  it("sorts the usernames in place", () => {
+    const lFixture = "tools/shared @team-unsorted";
+    const lTeamMapFixture = {
+      "team-unsorted": ["zus", "jan", "tjorus", "teun", "jet", "gijs"],
+    };
+    const lExpected = "tools/shared @gijs @jan @jet @teun @tjorus @zus";
+    equal(convert(lFixture, lTeamMapFixture, ""), lExpected);
   });
 });

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -86,5 +86,7 @@ function deduplicateUserNames(pTrimmedLine: string): string {
 
   return `${lSplitLine.groups.filesPattern}${Array.from(
     new Set(lSplitLine.groups.userNames.trim().split(/\s+/))
-  ).join(" ")}`;
+  )
+    .sort()
+    .join(" ")}`;
 }


### PR DESCRIPTION
## Description

- sorts the emitted lists of usernames

## Motivation and Context

The lists of CODEOWNERS on the lines can become large. Having the usernames sorted makes visual grepping easier.

## How Has This Been Tested?

- [x] green ci
- [x] adapted unit tests
- [x] additional unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
