### PR TITLE
refactor: deduplicates line  parsing

### DIFF
--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-const DEFAULT_GENERATED_WARNING = `#${EOL}` +
+const DEFAULT_WARNING = `#${EOL}` +
     `# DO NOT EDIT - this file is generated and your edits will be overwritten${EOL}` +
     `#${EOL}` +
     `# To make changes:${EOL}` +
@@ -8,14 +8,13 @@ const DEFAULT_GENERATED_WARNING = `#${EOL}` +
     `#   - and/ or add team members to .github/virtual-teams.yml${EOL}` +
     `#   - run 'npx virtual-code-owners'${EOL}` +
     `#${EOL}${EOL}`;
-const LINE_PATTERN = /^(?<filesPattern>[^\s]+\s+)(?<userNames>.*)$/;
-export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_GENERATED_WARNING) {
-    return `${pGeneratedWarning}${pCodeOwnersFileAsString
-        .split(EOL)
-        .filter(shouldAppearInResult)
-        .map(convertLine(pTeamMap))
-        .map(deduplicateUserNames)
-        .join(EOL)}`;
+export function convert(pCodeOwnersFileAsString, pTeamMap, pGeneratedWarning = DEFAULT_WARNING) {
+    return (pGeneratedWarning +
+        pCodeOwnersFileAsString
+            .split(EOL)
+            .filter(shouldAppearInResult)
+            .map(convertLine(pTeamMap))
+            .join(EOL));
 }
 function shouldAppearInResult(pLine) {
     return !pLine.trimStart().startsWith("#!");
@@ -23,34 +22,28 @@ function shouldAppearInResult(pLine) {
 function convertLine(pTeamMap) {
     return (pUntreatedLine) => {
         const lTrimmedLine = pUntreatedLine.trim();
-        if (lTrimmedLine.startsWith("#") || lTrimmedLine === "") {
+        const lSplitLine = lTrimmedLine.match(/^(?<filesPattern>[^\s]+\s+)(?<userNames>.*)$/);
+        if (lTrimmedLine.startsWith("#") ||
+            lTrimmedLine === "" ||
+            !lSplitLine?.groups) {
             return pUntreatedLine;
         }
-        else {
-            return replaceTeamNames(lTrimmedLine, pTeamMap);
-        }
+        const lUserNames = replaceTeamNames(lSplitLine.groups.userNames, pTeamMap);
+        return lSplitLine.groups.filesPattern + uniqAndSortUserNames(lUserNames);
     };
 }
-function replaceTeamNames(pTrimmedLine, pTeamMap) {
-    const lSplitLine = pTrimmedLine.match(LINE_PATTERN);
-    if (!lSplitLine?.groups) {
-        return pTrimmedLine;
-    }
-    let lUserNames = lSplitLine.groups.userNames.trim();
+function replaceTeamNames(pUserNames, pTeamMap) {
+    let lReturnValue = pUserNames;
     for (let lTeamName of Object.keys(pTeamMap)) {
-        lUserNames = lUserNames.replace(new RegExp(`(\\s|^)@${lTeamName}(\\s|$)`, "g"), `$1${stringifyTeamMembers(pTeamMap, lTeamName)}$2`);
+        lReturnValue = lReturnValue.replace(new RegExp(`(\\s|^)@${lTeamName}(\\s|$)`, "g"), `$1${stringifyTeamMembers(pTeamMap, lTeamName)}$2`);
     }
-    return `${lSplitLine.groups.filesPattern}${lUserNames}`;
+    return lReturnValue;
 }
 function stringifyTeamMembers(pTeamMap, pTeamName) {
     return pTeamMap[pTeamName].map((pUserName) => `@${pUserName}`).join(" ");
 }
-function deduplicateUserNames(pTrimmedLine) {
-    const lSplitLine = pTrimmedLine.match(LINE_PATTERN);
-    if (pTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
-        return pTrimmedLine;
-    }
-    return `${lSplitLine.groups.filesPattern}${Array.from(new Set(lSplitLine.groups.userNames.trim().split(/\s+/)))
+function uniqAndSortUserNames(pUserNames) {
+    return Array.from(new Set(pUserNames.split(/\s+/)))
         .sort()
-        .join(" ")}`;
+        .join(" ");
 }


### PR DESCRIPTION
## Description, Motivation and Context

- de-duplicates line parsing

we did this twice; once for replacing the  team names, and once for replacing user names. This is not necessary, and this PR acts on that.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
