### PR TITLE
refactor: makes line parsing more explicit

### DIFF
--- a/dist/convert-virtual-code-owners.js
+++ b/dist/convert-virtual-code-owners.js
@@ -22,12 +22,14 @@ function shouldAppearInResult(pLine) {
 function convertLine(pTeamMap) {
     return (pUntreatedLine) => {
         const lTrimmedLine = pUntreatedLine.trim();
-        const lSplitLine = lTrimmedLine.match(/^(?<filesPattern>[^\s]+\s+)(?<userNames>.*)$/);
+        const lSplitLine = lTrimmedLine.match(/^(?<filesPattern>[^\s]+)(?<spaces>\s+)(?<userNames>.*)$/);
         if (lTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
             return pUntreatedLine;
         }
         const lUserNames = replaceTeamNames(lSplitLine.groups.userNames, pTeamMap);
-        return lSplitLine.groups.filesPattern + uniqAndSortUserNames(lUserNames);
+        return (lSplitLine.groups.filesPattern +
+            lSplitLine.groups.spaces +
+            uniqAndSortUserNames(lUserNames));
     };
 }
 function replaceTeamNames(pUserNames, pTeamMap) {

--- a/src/convert-virtual-code-owners.ts
+++ b/src/convert-virtual-code-owners.ts
@@ -44,14 +44,18 @@ function convertLine(pTeamMap: ITeamMap) {
   return (pUntreatedLine: string): string => {
     const lTrimmedLine = pUntreatedLine.trim();
     const lSplitLine = lTrimmedLine.match(
-      /^(?<filesPattern>[^\s]+\s+)(?<userNames>.*)$/
+      /^(?<filesPattern>[^\s]+)(?<spaces>\s+)(?<userNames>.*)$/
     );
 
     if (lTrimmedLine.startsWith("#") || !lSplitLine?.groups) {
       return pUntreatedLine;
     }
     const lUserNames = replaceTeamNames(lSplitLine.groups.userNames, pTeamMap);
-    return lSplitLine.groups.filesPattern + uniqAndSortUserNames(lUserNames);
+    return (
+      lSplitLine.groups.filesPattern +
+      lSplitLine.groups.spaces +
+      uniqAndSortUserNames(lUserNames)
+    );
   };
 }
 


### PR DESCRIPTION
## Description

- makes line parsing more explicit, by naming the spaces as well

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
