### PR TITLE
feat(labeler.yml): adds a 'this file is generated' warning comment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,8 @@
 #
 #   - edit .github/VIRTUAL-CODEOWNERS.txt
 #   - and/ or add team members to .github/virtual-teams.yml
-#   - run 'npx virtual-code-owners'
+#   - run 'npx virtual-code-owners' (or 'npx virtual-code-owners --emitLabeler' if you also
+#     want to generate a .github/labeler.yml)
 #
 
 # catch-all to ensure there at least _is_ a code owner

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,17 @@
+#
+# DO NOT EDIT - this file is generated and your edits will be overwritten
+#
+# To make changes:
+#
+#   - edit .github/VIRTUAL-CODEOWNERS.txt
+#   - and/ or add teams (& members) to .github/virtual-teams.yml
+#   - run 'npx virtual-code-owners --emitLabeler'
+#
+
 vco:
-  - "**"
+  - '**'
 
 vco-admins:
   - .github/**
   - tools/**
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,9 +9,8 @@
 #
 
 vco:
-  - '**'
+  - "**"
 
 vco-admins:
   - .github/**
   - tools/**
-

--- a/dist/generate-codeowners.js
+++ b/dist/generate-codeowners.js
@@ -7,7 +7,8 @@ const DEFAULT_WARNING = `#${EOL}` +
     `#${EOL}` +
     `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
     `#   - and/ or add team members to .github/virtual-teams.yml${EOL}` +
-    `#   - run 'npx virtual-code-owners'${EOL}` +
+    `#   - run 'npx virtual-code-owners' (or 'npx virtual-code-owners --emitLabeler' if you also${EOL}` +
+    `#     want to generate a .github/labeler.yml)${EOL}` +
     `#${EOL}${EOL}`;
 export default function generateCodeOwners(pVirtualCodeOwners, pTeamMap, pGeneratedWarning = DEFAULT_WARNING) {
     return (pGeneratedWarning +

--- a/dist/generate-labeler-yml.js
+++ b/dist/generate-labeler-yml.js
@@ -1,6 +1,15 @@
 import { EOL } from "node:os";
-export default function generateLabelerYml(pCodeOwners, pTeamMap) {
-    let lReturnValue = "";
+const DEFAULT_WARNING = `#${EOL}` +
+    `# DO NOT EDIT - this file is generated and your edits will be overwritten${EOL}` +
+    `#${EOL}` +
+    `# To make changes:${EOL}` +
+    `#${EOL}` +
+    `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
+    `#   - and/ or add teams (& members) to .github/virtual-teams.yml${EOL}` +
+    `#   - run 'npx virtual-code-owners --emitLabeler'${EOL}` +
+    `#${EOL}${EOL}`;
+export default function generateLabelerYml(pCodeOwners, pTeamMap, pGeneratedWarning = DEFAULT_WARNING) {
+    let lReturnValue = pGeneratedWarning;
     for (const lTeamName in pTeamMap) {
         const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
             .map((pPattern) => `  - ${transformForYamlAndMinimatch(pPattern)}${EOL}`)

--- a/src/__fixtures__/CODEOWNERS
+++ b/src/__fixtures__/CODEOWNERS
@@ -5,7 +5,8 @@
 #
 #   - edit .github/VIRTUAL-CODEOWNERS.txt
 #   - and/ or add team members to .github/virtual-teams.yml
-#   - run 'npx virtual-code-owners'
+#   - run 'npx virtual-code-owners' (or 'npx virtual-code-owners --emitLabeler' if you also
+#     want to generate a .github/labeler.yml)
 #
 
 # catch-all to ensure there at least _is_ a code owner, even when

--- a/src/generate-codeowners.ts
+++ b/src/generate-codeowners.ts
@@ -15,7 +15,8 @@ const DEFAULT_WARNING =
   `#${EOL}` +
   `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
   `#   - and/ or add team members to .github/virtual-teams.yml${EOL}` +
-  `#   - run 'npx virtual-code-owners'${EOL}` +
+  `#   - run 'npx virtual-code-owners' (or 'npx virtual-code-owners --emitLabeler' if you also${EOL}` +
+  `#     want to generate a .github/labeler.yml)${EOL}` +
   `#${EOL}${EOL}`;
 
 export default function generateCodeOwners(

--- a/src/generate-labeler-yml.spec.ts
+++ b/src/generate-labeler-yml.spec.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual, equal } from "node:assert";
 import { readFileSync } from "node:fs";
+import { EOL } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
@@ -17,11 +18,11 @@ const TEAMS = {
 
 describe("generate-labeler-yml generates a labeler.yml", () => {
   it("empty virtual code owners & empty teams yields empty string", () => {
-    equal(generateLabelerYml([], {}), "");
+    equal(generateLabelerYml([], {}, ""), "");
   });
 
   it("empty virtual code owners  yields empty string", () => {
-    equal(generateLabelerYml([], TEAMS), "");
+    equal(generateLabelerYml([], TEAMS, ""), "");
   });
 
   it("virtual code owners with teams not matching any teams yields empty string", () => {
@@ -48,7 +49,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
         ],
       },
     ];
-    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS), "");
+    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), "");
   });
 
   it("virtual code owners with teams matching a rule yields the file pattern for that team", () => {
@@ -85,7 +86,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
   - knakkerdeknak/**
 
 `;
-    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS), lExpected);
+    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
   });
 
   it("rewrites glob magic from what gitignore/ codeowners uses what minimatch understands - '*'", () => {
@@ -110,7 +111,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
   - '**'
 
 `;
-    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS), lExpected);
+    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
   });
 
   it("rewrites glob magic from what gitignore/ codeowners uses what minimatch understands - starts with '*'", () => {
@@ -135,7 +136,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
   - '*/src/vlaai/*'
 
 `;
-    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS), lExpected);
+    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
   });
 
   it("rewrites glob magic from what gitignore/ codeowners uses what minimatch understands - ends with '/'", () => {
@@ -156,11 +157,18 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
         ],
       },
     ];
-    const lExpected = `baarden:
+    const lExpected = `# some header or other${EOL}baarden:
   - src/vlaai/**
 
 `;
-    equal(generateLabelerYml(lVirtualCodeOwners, TEAMS), lExpected);
+    equal(
+      generateLabelerYml(
+        lVirtualCodeOwners,
+        TEAMS,
+        `# some header or other${EOL}`
+      ),
+      lExpected
+    );
   });
 
   it("writes the kitchensink", () => {

--- a/src/generate-labeler-yml.ts
+++ b/src/generate-labeler-yml.ts
@@ -5,11 +5,23 @@ import type {
   IVirtualCodeOwnersCST,
 } from "types/types.js";
 
+const DEFAULT_WARNING =
+  `#${EOL}` +
+  `# DO NOT EDIT - this file is generated and your edits will be overwritten${EOL}` +
+  `#${EOL}` +
+  `# To make changes:${EOL}` +
+  `#${EOL}` +
+  `#   - edit .github/VIRTUAL-CODEOWNERS.txt${EOL}` +
+  `#   - and/ or add teams (& members) to .github/virtual-teams.yml${EOL}` +
+  `#   - run 'npx virtual-code-owners --emitLabeler'${EOL}` +
+  `#${EOL}${EOL}`;
+
 export default function generateLabelerYml(
   pCodeOwners: IVirtualCodeOwnersCST,
-  pTeamMap: ITeamMap
+  pTeamMap: ITeamMap,
+  pGeneratedWarning: string = DEFAULT_WARNING
 ): string {
-  let lReturnValue = "";
+  let lReturnValue = pGeneratedWarning;
   for (const lTeamName in pTeamMap) {
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
       .map((pPattern) => `  - ${transformForYamlAndMinimatch(pPattern)}${EOL}`)


### PR DESCRIPTION
## Description

- adds a 'this file is generated' warning comment at the top of .github/labeler.yml

## Motivation and Context

To reduce the number of accidents that will inevitably happen through inadvertently editing the generated .github/labeler.yml

## How Has This Been Tested?

- [x] green ci
- [x] updated automated tests
- [x] this PR still automatically labeled with both 'virtual-teams' as it touches both regular src & admin stuffsels

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
