### PR TITLE
refactor: re-organizes main

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-import { main } from "./main.js";
-main();
+import { cli } from "./main.js";
+cli();

--- a/dist/read-virtual-code-owners.js
+++ b/dist/read-virtual-code-owners.js
@@ -1,8 +1,27 @@
 import { readFileSync } from "node:fs";
-import { parse as parseVirtualCodeOwners } from "./parse.js";
+import { EOL } from "node:os";
+import { getAnomalies, parse as parseVirtualCodeOwners } from "./parse.js";
 export default function readVirtualCodeOwners(pVirtualCodeOwnersFileName, pTeamMap) {
     const lVirtualCodeOwnersAsAString = readFileSync(pVirtualCodeOwnersFileName, {
         encoding: "utf-8",
     });
-    return parseVirtualCodeOwners(lVirtualCodeOwnersAsAString, pTeamMap);
+    const lVirtualCodeOwners = parseVirtualCodeOwners(lVirtualCodeOwnersAsAString, pTeamMap);
+    const lAnomalies = getAnomalies(lVirtualCodeOwners);
+    if (lAnomalies.length > 0) {
+        throw new Error(`${EOL}${reportAnomalies(pVirtualCodeOwnersFileName, lAnomalies)}`);
+    }
+    return lVirtualCodeOwners;
+}
+function reportAnomalies(pFileName, pAnomalies) {
+    return pAnomalies
+        .map((pAnomaly) => {
+        if (pAnomaly.type === "invalid-line") {
+            return `${pFileName}:${pAnomaly.line}:1 invalid line - neither a rule, comment nor empty: '${pAnomaly.raw}'`;
+        }
+        else {
+            return (`${pFileName}:${pAnomaly.line}:1 invalid user or team name '${pAnomaly.raw}' (# ${pAnomaly.userNumberWithinLine} on this line). ` +
+                `It should either start with '@' or be an e-mail address.`);
+        }
+    })
+        .join(EOL);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import { main } from "./main.js";
+import { cli } from "./main.js";
 
-main();
+cli();

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,6 +1,6 @@
 import { match } from "node:assert";
 import { Writable } from "node:stream";
-import { main } from "./main.js";
+import { cli } from "./main.js";
 
 class WritableTestStream extends Writable {
   expected = /^$/;
@@ -21,8 +21,8 @@ describe("main", () => {
   it("shows the version number when asked for", () => {
     let lOutStream = new WritableTestStream(/^[0-9]+\.[0-9]+\.[0-9]+(-.+)?\n$/);
     let lErrStream = new WritableTestStream();
-    main(["-V"], lOutStream, lErrStream);
-    main(["--version"], lOutStream, lErrStream);
+    cli(["-V"], lOutStream, lErrStream);
+    cli(["--version"], lOutStream, lErrStream);
   });
 
   it("shows help when asked for", () => {
@@ -30,8 +30,8 @@ describe("main", () => {
       /^Usage: virtual-code-owners \[options\].*/
     );
     let lErrStream = new WritableTestStream();
-    main(["-h"], lOutStream, lErrStream);
-    main(["--help"], lOutStream, lErrStream);
+    cli(["-h"], lOutStream, lErrStream);
+    cli(["--help"], lOutStream, lErrStream);
   });
 
   it("shows an error when passed a non-existing argument", () => {
@@ -39,13 +39,13 @@ describe("main", () => {
     let lErrStream = new WritableTestStream(
       /.*ERROR:.*'--thisArgumentDoesNotExist'.*/
     );
-    main(["--thisArgumentDoesNotExist"], lOutStream, lErrStream);
+    cli(["--thisArgumentDoesNotExist"], lOutStream, lErrStream);
   });
 
   it("shows an error when passed a non-existing file", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream(/.*ERROR: ENOENT:.*/);
-    main(["-v", "this-file-does-not-exist.txt"], lOutStream, lErrStream);
+    cli(["-v", "this-file-does-not-exist.txt"], lOutStream, lErrStream);
   });
 
   it("shows an error when passed an invalid virtual-code-owners file", () => {
@@ -53,7 +53,7 @@ describe("main", () => {
     let lErrStream = new WritableTestStream(
       /.*\.\/src\/__mocks__\/erroneous-virtual-codeowners.txt:16:1 invalid user or team name 'jet' \(# 6 on this line\). It should either start with '@' or be an e-mail address.*/
     );
-    main(
+    cli(
       [
         "--virtualCodeOwners",
         "./src/__mocks__/erroneous-virtual-codeowners.txt",
@@ -73,9 +73,9 @@ describe("main", () => {
   it("ignores positional arguments", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream(
-      /.*Wrote node_modules\/tmp-code-owners\.txt.*/
+      /.*Wrote 'node_modules\/tmp-code-owners\.txt'.*/
     );
-    main(
+    cli(
       [
         "--virtualCodeOwners",
         "./src/__mocks__/VIRTUAL-CODEOWNERS.txt",
@@ -95,9 +95,9 @@ describe("main", () => {
   it("shows that both a codeowners and a labeler file were generated when --emitLabeler is used", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream(
-      /.*Wrote node_modules\/tmp-code-owners\.txt AND node_modules\/tmp-labeler.yml.*/
+      /.*Wrote 'node_modules\/tmp-code-owners\.txt' AND 'node_modules\/tmp-labeler.yml'.*/
     );
-    main(
+    cli(
       [
         "--virtualCodeOwners",
         "./src/__mocks__/VIRTUAL-CODEOWNERS.txt",

--- a/src/read-virtual-code-owners.ts
+++ b/src/read-virtual-code-owners.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
-import type { ITeamMap, IVirtualCodeOwnersCST } from "types/types.js";
-import { parse as parseVirtualCodeOwners } from "./parse.js";
+import { EOL } from "node:os";
+import type { IAnomaly, ITeamMap, IVirtualCodeOwnersCST } from "types/types.js";
+import { getAnomalies, parse as parseVirtualCodeOwners } from "./parse.js";
 
 export default function readVirtualCodeOwners(
   pVirtualCodeOwnersFileName: string,
@@ -9,5 +10,30 @@ export default function readVirtualCodeOwners(
   const lVirtualCodeOwnersAsAString = readFileSync(pVirtualCodeOwnersFileName, {
     encoding: "utf-8",
   });
-  return parseVirtualCodeOwners(lVirtualCodeOwnersAsAString, pTeamMap);
+  const lVirtualCodeOwners = parseVirtualCodeOwners(
+    lVirtualCodeOwnersAsAString,
+    pTeamMap
+  );
+  const lAnomalies = getAnomalies(lVirtualCodeOwners);
+  if (lAnomalies.length > 0) {
+    throw new Error(
+      `${EOL}${reportAnomalies(pVirtualCodeOwnersFileName, lAnomalies)}`
+    );
+  }
+  return lVirtualCodeOwners;
+}
+
+function reportAnomalies(pFileName: string, pAnomalies: IAnomaly[]): string {
+  return pAnomalies
+    .map((pAnomaly) => {
+      if (pAnomaly.type === "invalid-line") {
+        return `${pFileName}:${pAnomaly.line}:1 invalid line - neither a rule, comment nor empty: '${pAnomaly.raw}'`;
+      } else {
+        return (
+          `${pFileName}:${pAnomaly.line}:1 invalid user or team name '${pAnomaly.raw}' (# ${pAnomaly.userNumberWithinLine} on this line). ` +
+          `It should either start with '@' or be an e-mail address.`
+        );
+      }
+    })
+    .join(EOL);
 }


### PR DESCRIPTION
## Description

- moves throwing throwing a formatted parsing error to the spot that reads the virtual  codeowners 
- splits off  the  main functionality  in a function separate from the cli processing
- also puts quotes around the feedback  on  success  (`Wrote  '.github/CODEOWNERS'` instead  of `Wrote  .github/CODEOWNERS`) which  is better  for 

## Motivation and Context

looked a bit better to maintain

## How Has This Been Tested?

- [x] green ci
- [x] adapted automated tests (for the `'`s)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
