### PR TITLE
fix(generate-labeler-yml): emits " instead of ' to escape * in output

### DIFF
--- a/dist/generate-labeler-yml.js
+++ b/dist/generate-labeler-yml.js
@@ -35,7 +35,7 @@ function transformForYamlAndMinimatch(pOriginalString) {
         lReturnValue = "**";
     }
     if (lReturnValue.startsWith("*")) {
-        lReturnValue = `'${lReturnValue}'`;
+        lReturnValue = `"${lReturnValue}"`;
     }
     if (pOriginalString.endsWith("/")) {
         lReturnValue = `${lReturnValue}**`;

--- a/src/generate-labeler-yml.spec.ts
+++ b/src/generate-labeler-yml.spec.ts
@@ -108,7 +108,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-  - '**'
+  - "**"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -133,7 +133,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-  - '*/src/vlaai/*'
+  - "*/src/vlaai/*"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);

--- a/src/generate-labeler-yml.ts
+++ b/src/generate-labeler-yml.ts
@@ -69,7 +69,7 @@ function transformForYamlAndMinimatch(pOriginalString: string): string {
   // Something similar seems to go for values _starting_ with "*"
   // Quoted they're, OK, though so that's what we'll do:
   if (lReturnValue.startsWith("*")) {
-    lReturnValue = `'${lReturnValue}'`;
+    lReturnValue = `"${lReturnValue}"`;
   }
 
   // in CODEOWNERS a file pattern like src/bla/ means 'everything


### PR DESCRIPTION
## Description

Emits
```yaml
the-configgers:
  - "**/*config.js"
```

instead of 

```yaml
the-configgers:
  - ;**/*config.js'
```

## Motivation and Context

That's what prettier uses - so this will conflict a bit less with prettier'ing it

## How Has This Been Tested?

- [x] green ci
- [x] updated automated test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
