### PR TITLE
feat: adds dry run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,13 @@ npx virtual-code-owners --emitLabeler
 
 If you have an alternate file location for the `labeler.yml` you can specify that
 with virtual-code-owner's `--labelerLocation` parameter.
+
+### Can I just run virtual-code-owners to validate VIRTUAL-CODEOWNERS.txt & virtual-teams.yml?
+
+So _without_ generating any output?
+
+Yes. Use the `--dryRun` command line option:
+
+```
+npx virtual-code-owners --dryRun
+```

--- a/dist/main.js
+++ b/dist/main.js
@@ -25,6 +25,8 @@ Options:
                                        (default: false)
   --labelerLocation [file-name]        The location of the labeler.yml file
                                        (default: ".github/labeler.yml")
+  --dryRun                             Just validate inputs, don't generate
+                                       outputs (default: false)
   -h, --help                           display help for command`;
 export function cli(pArguments = process.argv.slice(2), pOutStream = process.stdout, pErrorStream = process.stderr) {
     try {
@@ -72,6 +74,10 @@ function getOptions(pArguments) {
                 type: "string",
                 default: ".github/labeler.yml",
             },
+            dryRun: {
+                type: "boolean",
+                default: false,
+            },
             help: { type: "boolean", short: "h", default: false },
             version: { type: "boolean", short: "V", default: false },
         },
@@ -84,14 +90,18 @@ function main(pOptions, pErrorStream) {
     const lTeamMap = readTeamMap(pOptions.virtualTeams);
     const lVirtualCodeOwners = readVirtualCodeOwners(pOptions.virtualCodeOwners, lTeamMap);
     const lCodeOwnersContent = generateCodeOwners(lVirtualCodeOwners, lTeamMap);
-    writeFileSync(pOptions.codeOwners, lCodeOwnersContent, {
-        encoding: "utf-8",
-    });
-    if (pOptions.emitLabeler) {
-        const lLabelerContent = generateLabelerYml(lVirtualCodeOwners, lTeamMap);
-        writeFileSync(pOptions.labelerLocation, lLabelerContent, {
+    if (!pOptions.dryRun) {
+        writeFileSync(pOptions.codeOwners, lCodeOwnersContent, {
             encoding: "utf-8",
         });
+    }
+    if (pOptions.emitLabeler) {
+        const lLabelerContent = generateLabelerYml(lVirtualCodeOwners, lTeamMap);
+        if (!pOptions.dryRun) {
+            writeFileSync(pOptions.labelerLocation, lLabelerContent, {
+                encoding: "utf-8",
+            });
+        }
         pErrorStream.write(`${EOL}Wrote '${pOptions.codeOwners}' AND '${pOptions.labelerLocation}'${EOL}${EOL}`);
     }
     else {

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,6 +1,7 @@
-import { match } from "node:assert";
+import { doesNotThrow, match, throws } from "node:assert";
 import { Writable } from "node:stream";
 import { cli } from "./main.js";
+import { accessSync, constants, rmSync } from "node:fs";
 
 class WritableTestStream extends Writable {
   expected: RegExp | RegExp[] = /^$/;
@@ -101,6 +102,29 @@ describe("main", () => {
     );
   });
 
+  it("with --dryRun, still shows an error when passed an invalid virtual-code-owners file", () => {
+    let lOutStream = new WritableTestStream();
+    let lErrStream = new WritableTestStream(
+      /.*\.\/src\/__mocks__\/erroneous-virtual-codeowners.txt:16:1 invalid user or team name "jet" \(#6 on this line\). It should either start with "@" or be an e-mail address.*/
+    );
+    cli(
+      [
+        "--virtualCodeOwners",
+        "./src/__mocks__/erroneous-virtual-codeowners.txt",
+        "--virtualTeams",
+        "./src/__mocks__/virtual-teams.yml",
+        "--codeOwners",
+        "node_modules/tmp-code-owners.txt",
+        "--emitLabeler",
+        "--labelerLocation",
+        "node_modules/tmp-labeler.yml",
+        "--dryRun",
+      ],
+      lOutStream,
+      lErrStream
+    );
+  });
+
   it("ignores positional arguments", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream(
@@ -123,10 +147,44 @@ describe("main", () => {
     );
   });
 
-  it("shows that both a codeowners and a labeler file were generated when --emitLabeler is used", () => {
+  it("shows that both a codeowners and a labeler file were generated when --emitLabeler is used + emits files", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream(
       /.*Wrote 'node_modules\/tmp-code-owners\.txt' AND 'node_modules\/tmp-labeler.yml'.*/
+    );
+    const lCodeOwnersFileName = "node_modules/tmp-code-owners.txt";
+    const lLabelerFileName = "node_modules/tmp-labeler.yml";
+    rmSync(lCodeOwnersFileName, { force: true });
+    rmSync(lLabelerFileName, { force: true });
+    cli(
+      [
+        "--virtualCodeOwners",
+        "./src/__mocks__/VIRTUAL-CODEOWNERS.txt",
+        "--virtualTeams",
+        "./src/__mocks__/virtual-teams.yml",
+        "--codeOwners",
+        lCodeOwnersFileName,
+        "--emitLabeler",
+        "--labelerLocation",
+        lLabelerFileName,
+      ],
+      lOutStream,
+      lErrStream
+    );
+    doesNotThrow(() => {
+      accessSync(lCodeOwnersFileName, constants.R_OK);
+    });
+    doesNotThrow(() => {
+      accessSync(lLabelerFileName, constants.R_OK);
+    });
+    rmSync(lCodeOwnersFileName, { force: true });
+    rmSync(lLabelerFileName, { force: true });
+  });
+
+  it("with --dryRun, still shows that both a codeowners and a labeler file were generated when --emitLabeler is used + does not emit files", () => {
+    let lOutStream = new WritableTestStream();
+    let lErrStream = new WritableTestStream(
+      /.*Wrote 'node_modules\/tmp-dry-run-so-shouldnt-exist-code-owners\.txt' AND 'node_modules\/tmp-dry-run-so-shouldnt-exist-labeler.yml'.*/
     );
     cli(
       [
@@ -135,13 +193,27 @@ describe("main", () => {
         "--virtualTeams",
         "./src/__mocks__/virtual-teams.yml",
         "--codeOwners",
-        "node_modules/tmp-code-owners.txt",
+        "node_modules/tmp-dry-run-so-shouldnt-exist-code-owners.txt",
         "--emitLabeler",
         "--labelerLocation",
-        "node_modules/tmp-labeler.yml",
+        "node_modules/tmp-dry-run-so-shouldnt-exist-labeler.yml",
+        "--dryRun",
       ],
       lOutStream,
       lErrStream
     );
+
+    throws(() => {
+      accessSync(
+        "node_modules/tmp-dry-run-so-shouldnt-exist-code-owners.txt",
+        constants.R_OK
+      );
+    }, /ENOENT/);
+    throws(() => {
+      accessSync(
+        "node_modules/tmp-dry-run-so-shouldnt-exist-labeler.yml",
+        constants.R_OK
+      );
+    }, /ENOENT/);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ interface IOptions {
   codeOwners: string;
   emitLabeler: boolean;
   labelerLocation: string;
+  dryRun: boolean;
   help: boolean;
   version: boolean;
 }
@@ -36,6 +37,8 @@ Options:
                                        (default: false)
   --labelerLocation [file-name]        The location of the labeler.yml file
                                        (default: ".github/labeler.yml")
+  --dryRun                             Just validate inputs, don't generate
+                                       outputs (default: false)
   -h, --help                           display help for command`;
 
 export function cli(
@@ -90,6 +93,10 @@ function getOptions(pArguments: string[]): IOptions {
         type: "string",
         default: ".github/labeler.yml",
       },
+      dryRun: {
+        type: "boolean",
+        default: false,
+      },
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", short: "V", default: false },
     },
@@ -109,15 +116,19 @@ function main(pOptions: IOptions, pErrorStream: Writable) {
   );
 
   const lCodeOwnersContent = generateCodeOwners(lVirtualCodeOwners, lTeamMap);
-  writeFileSync(pOptions.codeOwners, lCodeOwnersContent, {
-    encoding: "utf-8",
-  });
+  if (!pOptions.dryRun) {
+    writeFileSync(pOptions.codeOwners, lCodeOwnersContent, {
+      encoding: "utf-8",
+    });
+  }
 
   if (pOptions.emitLabeler) {
     const lLabelerContent = generateLabelerYml(lVirtualCodeOwners, lTeamMap);
-    writeFileSync(pOptions.labelerLocation, lLabelerContent, {
-      encoding: "utf-8",
-    });
+    if (!pOptions.dryRun) {
+      writeFileSync(pOptions.labelerLocation, lLabelerContent, {
+        encoding: "utf-8",
+      });
+    }
     pErrorStream.write(
       `${EOL}Wrote '${pOptions.codeOwners}' AND '${pOptions.labelerLocation}'${EOL}${EOL}`
     );


### PR DESCRIPTION
## Description

- adds a --dryRun command line option

## Motivation and Context

Useful for validation only scenarios (e.g. on a ci)

## How Has This Been Tested?

- [x] green ci
- [x] additional & adapted automated tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
