### PR TITLE
feat: sorts user names case insensitively

### DIFF
--- a/dist/generate-codeowners.js
+++ b/dist/generate-codeowners.js
@@ -20,7 +20,7 @@ export default function generateCodeOwners(pVirtualCodeOwners, pTeamMap, pGenera
 function generateLine(pCSTLine, pTeamMap) {
     if (pCSTLine.type === "rule") {
         const lUserNames = uniq(pCSTLine.users.flatMap((pUser) => expandTeamToUserNames(pUser, pTeamMap)))
-            .sort()
+            .sort(compareUserNames)
             .join(" ");
         return pCSTLine.filesPattern + pCSTLine.spaces + lUserNames;
     }
@@ -40,6 +40,9 @@ function userNameToCodeOwner(pUserName) {
         return pUserName;
     }
     return `@${pUserName}`;
+}
+function compareUserNames(pLeftName, pRightName) {
+    return pLeftName.toLowerCase() > pRightName.toLowerCase() ? 1 : -1;
 }
 function uniq(pUserNames) {
     return Array.from(new Set(pUserNames));

--- a/src/generate-codeowners.spec.ts
+++ b/src/generate-codeowners.spec.ts
@@ -191,6 +191,26 @@ tools/ @team-tgif`;
     );
   });
 
+  it("sorts the usernames in place - ignoring case", () => {
+    const lFixture = "tools/shared @team-unsorted";
+    const lTeamMapFixture = {
+      "team-unsorted": [
+        "zus",
+        "Jantje",
+        "jan",
+        "tjorus",
+        "teun",
+        "jet",
+        "gijs",
+      ],
+    };
+    const lExpected = "tools/shared @gijs @jan @Jantje @jet @teun @tjorus @zus";
+    equal(
+      generateCodeOwnersFromString(lFixture, lTeamMapFixture, ""),
+      lExpected
+    );
+  });
+
   it("writes the kitchensink", () => {
     const lTeamMap = readTeamMap(
       join(__dirname, "__mocks__", "virtual-teams.yml")

--- a/src/generate-codeowners.ts
+++ b/src/generate-codeowners.ts
@@ -41,7 +41,7 @@ function generateLine(
     const lUserNames = uniq(
       pCSTLine.users.flatMap((pUser) => expandTeamToUserNames(pUser, pTeamMap))
     )
-      .sort()
+      .sort(compareUserNames)
       .join(" ");
     return pCSTLine.filesPattern + pCSTLine.spaces + lUserNames;
   }
@@ -64,6 +64,10 @@ function userNameToCodeOwner(pUserName: string): string {
     return pUserName;
   }
   return `@${pUserName}`;
+}
+
+function compareUserNames(pLeftName: string, pRightName: string): number {
+  return pLeftName.toLowerCase() > pRightName.toLowerCase() ? 1 : -1;
 }
 
 function uniq(pUserNames: string[]): string[] {


### PR DESCRIPTION
## Description

- sorts usernames, ignoring case

## Motivation and Context

Make resulting CODEOWNERS files easier to scan/ check.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
