### PR TITLE
refactor(test): uses new URL canonically

### DIFF
--- a/src/generate-codeowners.spec.ts
+++ b/src/generate-codeowners.spec.ts
@@ -1,15 +1,11 @@
 import { deepStrictEqual, equal } from "node:assert";
 import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { ITeamMap } from "../types/types.js";
 import generateCodeOwners from "./generate-codeowners.js";
 import { parse } from "./parse-virtual-code-owners.js";
 import readTeamMap from "./read-team-map.js";
 import readVirtualCodeOwners from "./read-virtual-code-owners.js";
-
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export function generateCodeOwnersFromString(
   pCodeOwnersFileAsString: string,
@@ -213,14 +209,14 @@ tools/ @team-tgif`;
 
   it("writes the kitchensink", () => {
     const lTeamMap = readTeamMap(
-      join(__dirname, "__mocks__", "virtual-teams.yml")
+      new URL("./__mocks__/virtual-teams.yml", import.meta.url).pathname
     );
     const lVirtualCodeOwners = readVirtualCodeOwners(
-      join(__dirname, "__mocks__", "VIRTUAL-CODEOWNERS.txt"),
+      new URL("./__mocks__/VIRTUAL-CODEOWNERS.txt", import.meta.url).pathname,
       lTeamMap
     );
     const lExpected = readFileSync(
-      join(__dirname, "__fixtures__", "CODEOWNERS"),
+      new URL("./__fixtures__/CODEOWNERS", import.meta.url),
       "utf-8"
     );
     const lFound = generateCodeOwners(lVirtualCodeOwners, lTeamMap);

--- a/src/generate-labeler-yml.spec.ts
+++ b/src/generate-labeler-yml.spec.ts
@@ -1,15 +1,11 @@
 import { deepStrictEqual, equal } from "node:assert";
 import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { IVirtualCodeOwnersCST } from "../types/types.js";
 import generateLabelerYml from "./generate-labeler-yml.js";
 import readTeamMap from "./read-team-map.js";
 import readVirtualCodeOwners from "./read-virtual-code-owners.js";
-
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const TEAMS = {
   "the-a-team": ["smith", "baracus", "peck", "murdock"],
@@ -173,14 +169,17 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
 
   it("writes the kitchensink", () => {
     const lTeamMap = readTeamMap(
-      join(__dirname, "__mocks__", "virtual-teams.yml")
+      new URL("./__mocks__/virtual-teams.yml", import.meta.url).pathname
     );
     const lVirtualCodeOwners = readVirtualCodeOwners(
-      join(__dirname, "__mocks__", "VIRTUAL-CODEOWNERS.txt"),
+      new URL("./__mocks__/VIRTUAL-CODEOWNERS.txt", import.meta.url).pathname,
       lTeamMap
     );
     const lExpected = parseYaml(
-      readFileSync(join(__dirname, "__fixtures__", "labeler.yml"), "utf-8")
+      readFileSync(
+        new URL("./__fixtures__/labeler.yml", import.meta.url),
+        "utf-8"
+      )
     );
     const lFound = parseYaml(generateLabelerYml(lVirtualCodeOwners, lTeamMap));
     deepStrictEqual(lFound, lExpected);

--- a/src/parse-virtual-code-owners.spec.ts
+++ b/src/parse-virtual-code-owners.spec.ts
@@ -1,18 +1,18 @@
 import { deepStrictEqual } from "node:assert";
 import { readFileSync, readdirSync } from "node:fs";
 import { extname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { IVirtualCodeOwnersCST } from "../types/types.js";
 import { getAnomalies, parse } from "./parse-virtual-code-owners.js";
 
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
-
 function relEmpty(pFileName) {
-  return join(__dirname, "__fixtures__/corpus/empty-teams", pFileName);
+  return new URL(
+    join("__fixtures__/corpus/empty-teams", pFileName),
+    import.meta.url
+  );
 }
 function rel(pFileName) {
-  return join(__dirname, "__fixtures__/corpus/teams", pFileName);
+  return new URL(join("__fixtures__/corpus/teams", pFileName), import.meta.url);
 }
 function getOutputFileName(pFileName) {
   return pFileName.replace(/\.txt$/, ".yml");
@@ -26,7 +26,9 @@ const TEAMS = {
 
 describe("parses VIRTUAL-CODEOWNERS.txt - empty 'virtual teams'", () => {
   readdirSync(relEmpty(""))
-    .filter((pFileName: string) => extname(relEmpty(pFileName)) === ".txt")
+    .filter(
+      (pFileName: string) => extname(relEmpty(pFileName).pathname) === ".txt"
+    )
     .sort()
     .forEach((pFileName: string) => {
       const lInput = readFileSync(relEmpty(pFileName), "utf-8");
@@ -41,7 +43,7 @@ describe("parses VIRTUAL-CODEOWNERS.txt - empty 'virtual teams'", () => {
 });
 describe("parses VIRTUAL-CODEOWNERS.txt - with 'virtual teams'", () => {
   readdirSync(rel(""))
-    .filter((pFileName: string) => extname(rel(pFileName)) === ".txt")
+    .filter((pFileName: string) => extname(rel(pFileName).pathname) === ".txt")
     .sort()
     .forEach((pFileName: string) => {
       const lInput = readFileSync(rel(pFileName), "utf-8");


### PR DESCRIPTION
## Description

- replaces all commonjs looking `__dirname` constructs with the canonical way to do it in ESM

## Motivation and Context

looks cleaner

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
