### PR TITLE
refactor(test): replaces mocha with node:test

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,6 +4,6 @@
   "branches": 100,
   "functions": 100,
   "lines": 100,
-  "exclude": ["{src/**/*.spec.ts,.mocharc.cjs}"],
+  "exclude": ["{src/**/*.test.ts}"],
   "reporter": ["text-summary", "html", "json-summary"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           yarn --silent depcruise --output-type markdown >> $GITHUB_STEP_SUMMARY
           echo '## Visual overview' >> $GITHUB_STEP_SUMMARY
           echo '```mermaid' >> $GITHUB_STEP_SUMMARY
-          yarn --silent depcruise --exclude ".spec.ts$" --include-only "^(src)" --output-type mermaid >> $GITHUB_STEP_SUMMARY
+          yarn --silent depcruise --exclude ".test.ts$" --include-only "^(src)" --output-type mermaid >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: on pull requests emit depcruise results + diff graph to step summary
         if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'pull_request' && github.ref_name != github.event.repository.default_branch

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  extension: ["ts"],
-  reporter: "dot",
-  spec: "src/**/*.spec.ts",
-  loader: "ts-node/esm",
-};

--- a/dist/main.js
+++ b/dist/main.js
@@ -28,7 +28,7 @@ Options:
   --dryRun                             Just validate inputs, don't generate
                                        outputs (default: false)
   -h, --help                           display help for command`;
-export function cli(pArguments = process.argv.slice(2), pOutStream = process.stdout, pErrorStream = process.stderr) {
+export function cli(pArguments = process.argv.slice(2), pOutStream = process.stdout, pErrorStream = process.stderr, pErrorExitCode = 1) {
     try {
         const lOptions = getOptions(pArguments);
         if (lOptions.help) {
@@ -43,7 +43,7 @@ export function cli(pArguments = process.argv.slice(2), pOutStream = process.std
     }
     catch (pError) {
         pErrorStream.write(`${EOL}ERROR: ${pError.message}${EOL}${EOL}`);
-        process.exitCode = 1;
+        process.exitCode = pErrorExitCode;
     }
 }
 function getOptions(pArguments) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "format": "prettier --log-level warn --write \"**/*.{md,ts,json,yml}\"",
     "prepare": "husky install",
     "scm:stage": "git add .",
-    "test": "NODE_OPTIONS=--no-warnings c8 mocha",
+    "test": "c8 node --no-warnings --loader 'ts-node/esm' --test-reporter dot --test src/*.test.ts",
     "update-dependencies": "npm run upem:update && npm run upem:install && npm run check",
     "upem-outdated": "npm outdated --json --long | upem --dry-run",
     "upem:install": "npm install",
@@ -69,13 +69,11 @@
     "url": "https://github.com/sverweij/virtual-code-owners/issues"
   },
   "devDependencies": {
-    "@types/mocha": "10.0.1",
     "@types/node": "20.4.1",
     "c8": "8.0.0",
     "dependency-cruiser": "13.1.0",
     "husky": "8.0.3",
     "lint-staged": "13.2.3",
-    "mocha": "10.2.0",
     "prettier": "3.0.0",
     "ts-node": "10.9.1",
     "typescript": "5.1.6",

--- a/src/generate-codeowners.test.ts
+++ b/src/generate-codeowners.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, equal } from "node:assert";
 import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
+import { describe, it } from "node:test";
 import type { ITeamMap } from "../types/types.js";
 import generateCodeOwners from "./generate-codeowners.js";
 import { parse } from "./parse-virtual-code-owners.js";

--- a/src/generate-labeler-yml.test.ts
+++ b/src/generate-labeler-yml.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, equal } from "node:assert";
 import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
+import { describe, it } from "node:test";
 import { parse as parseYaml } from "yaml";
 import type { IVirtualCodeOwnersCST } from "../types/types.js";
 import generateLabelerYml from "./generate-labeler-yml.js";

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,7 +1,8 @@
 import { doesNotThrow, match, throws } from "node:assert";
-import { Writable } from "node:stream";
-import { cli } from "./main.js";
 import { accessSync, constants, rmSync } from "node:fs";
+import { Writable } from "node:stream";
+import { describe, it } from "node:test";
+import { cli } from "./main.js";
 
 class WritableTestStream extends Writable {
   expected: RegExp | RegExp[] = /^$/;
@@ -46,7 +47,7 @@ describe("main", () => {
     let lErrStream = new WritableTestStream(
       /.*ERROR:.*'--thisArgumentDoesNotExist'.*/,
     );
-    cli(["--thisArgumentDoesNotExist"], lOutStream, lErrStream);
+    cli(["--thisArgumentDoesNotExist"], lOutStream, lErrStream, 0);
   });
 
   it("shows an error when passed a non-existing file", () => {
@@ -77,6 +78,7 @@ describe("main", () => {
       ],
       lOutStream,
       lErrStream,
+      0,
     );
   });
 
@@ -99,6 +101,7 @@ describe("main", () => {
       ],
       lOutStream,
       lErrStream,
+      0,
     );
   });
 
@@ -122,6 +125,7 @@ describe("main", () => {
       ],
       lOutStream,
       lErrStream,
+      0,
     );
   });
 
@@ -170,6 +174,7 @@ describe("main", () => {
       ],
       lOutStream,
       lErrStream,
+      0,
     );
     doesNotThrow(() => {
       accessSync(lCodeOwnersFileName, constants.R_OK);
@@ -201,6 +206,7 @@ describe("main", () => {
       ],
       lOutStream,
       lErrStream,
+      0,
     );
 
     throws(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ export function cli(
   pArguments: string[] = process.argv.slice(2),
   pOutStream: Writable = process.stdout,
   pErrorStream: Writable = process.stderr,
+  pErrorExitCode: number = 1,
 ) {
   try {
     const lOptions = getOptions(pArguments);
@@ -61,7 +62,7 @@ export function cli(
     main(lOptions, pErrorStream);
   } catch (pError: any) {
     pErrorStream.write(`${EOL}ERROR: ${pError.message}${EOL}${EOL}`);
-    process.exitCode = 1;
+    process.exitCode = pErrorExitCode;
   }
 }
 

--- a/src/parse-virtual-code-owners.test.ts
+++ b/src/parse-virtual-code-owners.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual } from "node:assert";
 import { readFileSync, readdirSync } from "node:fs";
 import { extname, join } from "node:path";
+import { describe, it } from "node:test";
 import { parse as parseYaml } from "yaml";
 import type { IVirtualCodeOwnersCST } from "../types/types.js";
 import { getAnomalies, parse } from "./parse-virtual-code-owners.js";

--- a/tools/dependency-cruiser-config/options.yml
+++ b/tools/dependency-cruiser-config/options.yml
@@ -32,7 +32,7 @@ reporterOptions:
             fillcolor: lime
             penwidth: 2
         - criteria:
-            source: ".spec.ts"
+            source: ".test.ts"
           attributes:
             fillcolor: "#ccccff"
   text:

--- a/tools/dependency-cruiser-config/rules.yml
+++ b/tools/dependency-cruiser-config/rules.yml
@@ -86,6 +86,9 @@
   from: {}
   to:
     couldNotResolve: true
+    # https://github.com/nodejs/node/issues/42785 - node:test is not enumerated in builtinModules
+    # and won't ever be. Workaround in dependency-cruiser coming up. For now: ignore node:test
+    pathNot: "test"
 - name: no-duplicate-dep-types
   comment:
     Likely this module depends on an external ('npm') package that occurs more
@@ -107,7 +110,7 @@
   severity: error
   from: {}
   to:
-    path: "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$"
+    path: "\\.test\\.ts$"
 - name: not-to-dev-dep
   severity: error
   comment:
@@ -119,7 +122,7 @@
     the dependency-cruiser configuration
   from:
     path: "^(src)"
-    pathNot: "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$"
+    pathNot: "\\.test\\.ts$"
   to:
     dependencyTypes:
       - npm-dev

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,7 +101,7 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"],
+  "exclude": ["src/**/*.test.ts"],
   "ts-node": {
     "transpileOnly": true,
     "files": true


### PR DESCRIPTION
## Description

- replaces `mocha` with node's own `node:test` module

## Motivation and Context

Less dependencies = less maintenance

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
