### PR TITLE
feat(generate): adds support for inline comments in rule lines

### DIFF
--- a/dist/generate-codeowners.js
+++ b/dist/generate-codeowners.js
@@ -22,7 +22,10 @@ function generateLine(pCSTLine, pTeamMap) {
         const lUserNames = uniq(pCSTLine.users.flatMap((pUser) => expandTeamToUserNames(pUser, pTeamMap)))
             .sort(compareUserNames)
             .join(" ");
-        return pCSTLine.filesPattern + pCSTLine.spaces + lUserNames;
+        return (pCSTLine.filesPattern +
+            pCSTLine.spaces +
+            lUserNames +
+            (pCSTLine.inlineComment ? ` #${pCSTLine.inlineComment}` : ""));
     }
     return pCSTLine.raw;
 }

--- a/src/generate-codeowners.test.ts
+++ b/src/generate-codeowners.test.ts
@@ -208,6 +208,19 @@ tools/ @team-tgif`;
     );
   });
 
+  it("re-adds any inline comment", () => {
+    const lFixture = "no-plan-b/ @team    # this is a comment";
+    const lTeamMapFixture = {
+      team: ["b.a.barackus", "face", "hannibal", "murdock"],
+    };
+    const lExpected =
+      "no-plan-b/ @b.a.barackus @face @hannibal @murdock # this is a comment";
+    equal(
+      generateCodeOwnersFromString(lFixture, lTeamMapFixture, ""),
+      lExpected,
+    );
+  });
+
   it("writes the kitchensink", () => {
     const lTeamMap = readTeamMap(
       new URL("./__mocks__/virtual-teams.yml", import.meta.url).pathname,

--- a/src/generate-codeowners.ts
+++ b/src/generate-codeowners.ts
@@ -43,7 +43,12 @@ function generateLine(
     )
       .sort(compareUserNames)
       .join(" ");
-    return pCSTLine.filesPattern + pCSTLine.spaces + lUserNames;
+    return (
+      pCSTLine.filesPattern +
+      pCSTLine.spaces +
+      lUserNames +
+      (pCSTLine.inlineComment ? ` #${pCSTLine.inlineComment}` : "")
+    );
   }
   return pCSTLine.raw;
 }


### PR DESCRIPTION
## Description

- adds support for inline comments in rule lines in the code that generates the CODEOWNERS file

## Motivation and Context

See #115 


## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
