### PR TITLE
refactor: load teams json schema from a module

### DIFF
--- a/dist/team-map/read.js
+++ b/dist/team-map/read.js
@@ -2,7 +2,7 @@ import Ajv from "ajv";
 import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
 import { parse as parseYaml } from "yaml";
-const TEAM_MAP_SCHEMA = JSON.parse(readFileSync(new URL("../virtual-teams.schema.json", import.meta.url), "utf-8"));
+import virtualTeamsSchema from "./virtual-teams.schema.js";
 export default function readTeamMap(pVirtualTeamsFileName) {
     const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
         encoding: "utf-8",
@@ -16,7 +16,7 @@ function assertTeamMapValid(pTeamMap, pVirtualTeamsFileName) {
         allErrors: true,
         verbose: true,
     });
-    if (!ajv.validate(TEAM_MAP_SCHEMA, pTeamMap)) {
+    if (!ajv.validate(virtualTeamsSchema, pTeamMap)) {
         throw new Error(`This is not a valid virtual-teams.yml:${EOL}${formatAjvErrors(ajv.errors, pVirtualTeamsFileName)}.\n`);
     }
 }

--- a/dist/team-map/virtual-teams.schema.js
+++ b/dist/team-map/virtual-teams.schema.js
@@ -1,0 +1,15 @@
+export default {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: "virtual teams schema for virtual-code-owners",
+    description: "a list of teams and their team members",
+    $id: "org.js.virtual-code-owners/7.0.0",
+    type: "object",
+    additionalProperties: {
+        type: "array",
+        items: {
+            type: "string",
+            description: "Username or e-mail address of a team member. (Don't prefix usernames with '@')",
+            pattern: "^[^@][^\\s]+$",
+        },
+    },
+};

--- a/dist/virtual-teams.schema.json
+++ b/dist/virtual-teams.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "virtual teams schema for virtual-code-owners",
   "description": "a list of teams and their team members",
-  "$id": "org.js.virtual-code-owners/6.0.0",
+  "$id": "org.js.virtual-code-owners/7.0.0",
   "type": "object",
   "additionalProperties": {
     "type": "array",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && node --no-warnings --loader tsx tools/get-version.ts > src/version.ts && tsc && cp -f src/*.json dist/.",
+    "build": "rm -rf dist && tsx tools/get-version.ts > src/version.ts && tsx tools/js-json.ts < src/virtual-teams.schema.json > src/team-map/virtual-teams.schema.ts && tsc && cp -f src/*.json dist/.",
     "check": "npm run format && npm run build && npm run depcruise -- --no-progress && npm test",
     "depcruise": "depcruise src tools",
     "depcruise:graph": "depcruise src --include-only '^(src)' --output-type dot | dot -T svg | depcruise-wrap-stream-in-html > dependency-graph.html",

--- a/src/team-map/read.ts
+++ b/src/team-map/read.ts
@@ -3,13 +3,7 @@ import { readFileSync } from "node:fs";
 import { EOL } from "node:os";
 import type { ITeamMap } from "./team-map.js";
 import { parse as parseYaml } from "yaml";
-
-const TEAM_MAP_SCHEMA = JSON.parse(
-  readFileSync(
-    new URL("../virtual-teams.schema.json", import.meta.url),
-    "utf-8",
-  ),
-);
+import virtualTeamsSchema from "./virtual-teams.schema.js";
 
 export default function readTeamMap(pVirtualTeamsFileName: string): ITeamMap {
   const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
@@ -29,7 +23,7 @@ function assertTeamMapValid(pTeamMap: ITeamMap, pVirtualTeamsFileName: string) {
     verbose: true,
   });
 
-  if (!ajv.validate(TEAM_MAP_SCHEMA, pTeamMap)) {
+  if (!ajv.validate(virtualTeamsSchema, pTeamMap)) {
     throw new Error(
       `This is not a valid virtual-teams.yml:${EOL}${formatAjvErrors(
         ajv.errors,

--- a/src/team-map/virtual-teams.schema.ts
+++ b/src/team-map/virtual-teams.schema.ts
@@ -1,0 +1,16 @@
+export default {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  title: "virtual teams schema for virtual-code-owners",
+  description: "a list of teams and their team members",
+  $id: "org.js.virtual-code-owners/7.0.0",
+  type: "object",
+  additionalProperties: {
+    type: "array",
+    items: {
+      type: "string",
+      description:
+        "Username or e-mail address of a team member. (Don't prefix usernames with '@')",
+      pattern: "^[^@][^\\s]+$",
+    },
+  },
+};

--- a/src/virtual-teams.schema.json
+++ b/src/virtual-teams.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "virtual teams schema for virtual-code-owners",
   "description": "a list of teams and their team members",
-  "$id": "org.js.virtual-code-owners/6.0.0",
+  "$id": "org.js.virtual-code-owners/7.0.0",
   "type": "object",
   "additionalProperties": {
     "type": "array",

--- a/tools/js-json.ts
+++ b/tools/js-json.ts
@@ -1,0 +1,24 @@
+import prettier from "prettier";
+
+function getStream(pStream: NodeJS.ReadStream): Promise<string> {
+  return new Promise((pResolve, pReject) => {
+    let lInputAsString = "";
+
+    pStream
+      .on("data", (pChunk) => {
+        lInputAsString += pChunk;
+      })
+      .on("error", pReject)
+      .on("end", () => {
+        pResolve(lInputAsString);
+      });
+  });
+}
+
+const lTheThing = await getStream(process.stdin);
+const lTheFormattedThing = await prettier.format(
+  `export default ${lTheThing};`,
+  { parser: "babel" },
+);
+
+process.stdout.write(lTheFormattedThing);


### PR DESCRIPTION
## Description

- loads the teams json schema from a module instead of from a .json
- 🏕️ bumps the schema version to match the (upcoming) version of virtual-code-owners

## Motivation and Context

- code looks easier
- speed wise it doesn't make a noticeable difference (readFileSync + JSON.parse should theoretically be faster as the json parser is simpler, and no module resolution needs to take place - but I guess as the schema is tiny it doesn't matter that much for this use case)
- it _does_ enable for easier bundling (which we're not going to do despite the resulting code running 4-6% faster - the reduced transparency is not worth the hardly noticeable 15ms of 150-250ms (on my slow 2017 machine)).

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
