### PR TITLE
feat(labeler.yml): changes --emitLabeler to emit  labeler@v5 format labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,18 +9,24 @@
 #
 
 vco:
-  - "**"
-  - README.md
+- changed-files:
+  - any-glob-to-any-file: "**"
+  - any-glob-to-any-file: README.md
 
 vco-admins:
-  - .github/**
-  - tools/**
+- changed-files:
+  - any-glob-to-any-file: .github/**
+  - any-glob-to-any-file: tools/**
 
 tools:
-  - tools/**
+- changed-files:
+  - any-glob-to-any-file: tools/**
 
 admin:
-  - .github/**
+- changed-files:
+  - any-glob-to-any-file: .github/**
 
 documentation:
-  - README.md
+- changed-files:
+  - any-glob-to-any-file: README.md
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,24 +9,23 @@
 #
 
 vco:
-- changed-files:
-  - any-glob-to-any-file: "**"
-  - any-glob-to-any-file: README.md
+  - changed-files:
+      - any-glob-to-any-file: "**"
+      - any-glob-to-any-file: README.md
 
 vco-admins:
-- changed-files:
-  - any-glob-to-any-file: .github/**
-  - any-glob-to-any-file: tools/**
+  - changed-files:
+      - any-glob-to-any-file: .github/**
+      - any-glob-to-any-file: tools/**
 
 tools:
-- changed-files:
-  - any-glob-to-any-file: tools/**
+  - changed-files:
+      - any-glob-to-any-file: tools/**
 
 admin:
-- changed-files:
-  - any-glob-to-any-file: .github/**
+  - changed-files:
+      - any-glob-to-any-file: .github/**
 
 documentation:
-- changed-files:
-  - any-glob-to-any-file: README.md
-
+  - changed-files:
+      - any-glob-to-any-file: README.md

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,3 +29,4 @@ admin:
 documentation:
   - changed-files:
       - any-glob-to-any-file: README.md
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           sync-labels: true
           dot: true

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ npx virtual-code-owners --emitLabeler
 If you have an alternate file location for the `labeler.yml` you can specify that
 with virtual-code-owner's `--labelerLocation` parameter.
 
+> [!NOTE]
+> actions/labeler changed the labeler.yml format from v4 to v5.
+>
+> - virtual-code-owners < 8.0.0 generates labeler.yml v4 format,
+> - virtual-code-owners >= 8.0.0 generates labeler.yml v5 format.
+>
+> see [actions/labeler#v5](https://github.com/actions/labeler/blob/8558fd74291d67161a8a78ce36a881fa63b766a9/README.md)
+> for details on the v5 format.
+
 ### What validations does virtual-code-owners perform?
 
 virtual-code-owners checks for basic CODEOWNERS format errors and invalid

--- a/dist/labeler-yml/generate.js
+++ b/dist/labeler-yml/generate.js
@@ -17,10 +17,15 @@ export default function generateLabelerYml(
   let lReturnValue = pGeneratedWarning;
   for (const lTeamName in pTeamMap) {
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
-      .map((pPattern) => `  - ${transformForYamlAndMinimatch(pPattern)}${EOL}`)
+      .map(
+        (pPattern) =>
+          `  - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+            pPattern,
+          )}${EOL}`,
+      )
       .join("");
     if (lPatternsForTeam) {
-      lReturnValue += `${lTeamName}:${EOL}${lPatternsForTeam}${EOL}`;
+      lReturnValue += `${lTeamName}:${EOL}- changed-files:${EOL}${lPatternsForTeam}${EOL}`;
     }
   }
   return lReturnValue;

--- a/dist/labeler-yml/generate.js
+++ b/dist/labeler-yml/generate.js
@@ -19,7 +19,7 @@ export default function generateLabelerYml(
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
       .map(
         (pPattern) =>
-          `    - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+          `      - any-glob-to-any-file: ${transformForYamlAndMinimatch(
             pPattern,
           )}${EOL}`,
       )

--- a/dist/labeler-yml/generate.js
+++ b/dist/labeler-yml/generate.js
@@ -19,13 +19,13 @@ export default function generateLabelerYml(
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
       .map(
         (pPattern) =>
-          `  - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+          `    - any-glob-to-any-file: ${transformForYamlAndMinimatch(
             pPattern,
           )}${EOL}`,
       )
       .join("");
     if (lPatternsForTeam) {
-      lReturnValue += `${lTeamName}:${EOL}- changed-files:${EOL}${lPatternsForTeam}${EOL}`;
+      lReturnValue += `${lTeamName}:${EOL}  - changed-files:${EOL}${lPatternsForTeam}${EOL}`;
     }
   }
   return lReturnValue;

--- a/src/labeler-yml/__fixtures__/labeler.yml
+++ b/src/labeler-yml/__fixtures__/labeler.yml
@@ -1,22 +1,28 @@
 ch/after-sales:
-  - libs/ubc-after-sales/**
-  - libs/ubc-refund/**
+  - changed-files:
+      - any-glob-to-any-file: libs/ubc-after-sales/**
+      - any-glob-to-any-file: libs/ubc-refund/**
 
 ch/sales:
-  - libs/ubc-sales/**
-  - libs/ubc-refund/**
+  - changed-files:
+      - any-glob-to-any-file: libs/ubc-sales/**
+      - any-glob-to-any-file: libs/ubc-refund/**
 
 ch/pre-sales:
-  - libs/ubc-pre-sales/**
+  - changed-files:
+      - any-glob-to-any-file: libs/ubc-pre-sales/**
 
 ch/ux:
-  - apps/ux-portal/**
-  - libs/components/**
+  - changed-files:
+      - any-glob-to-any-file: apps/ux-portal/**
+      - any-glob-to-any-file: libs/components/**
 
 ch/transversal:
-  - .github/**
-  - apps/framework/**
-  - apps/ux-portal/**
+  - changed-files:
+      - any-glob-to-any-file: .github/**
+      - any-glob-to-any-file: apps/framework/**
+      - any-glob-to-any-file: apps/ux-portal/**
 
 ch/mannen-met-baarden:
-  - libs/ubc-baarden/**
+  - changed-files:
+      - any-glob-to-any-file: libs/ubc-baarden/**

--- a/src/labeler-yml/generate.test.ts
+++ b/src/labeler-yml/generate.test.ts
@@ -82,7 +82,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `the-a-team:
-  - knakkerdeknak/**
+- changed-files:
+  - any-glob-to-any-file: knakkerdeknak/**
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -108,7 +109,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-  - "**"
+- changed-files:
+  - any-glob-to-any-file: "**"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -134,7 +136,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-  - "*/src/vlaai/*"
+- changed-files:
+  - any-glob-to-any-file: "*/src/vlaai/*"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -160,7 +163,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `# some header or other${EOL}baarden:
-  - src/vlaai/**
+- changed-files:
+  - any-glob-to-any-file: src/vlaai/**
 
 `;
     equal(

--- a/src/labeler-yml/generate.test.ts
+++ b/src/labeler-yml/generate.test.ts
@@ -82,8 +82,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `the-a-team:
-- changed-files:
-  - any-glob-to-any-file: knakkerdeknak/**
+  - changed-files:
+    - any-glob-to-any-file: knakkerdeknak/**
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -109,8 +109,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-- changed-files:
-  - any-glob-to-any-file: "**"
+  - changed-files:
+    - any-glob-to-any-file: "**"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -136,8 +136,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `baarden:
-- changed-files:
-  - any-glob-to-any-file: "*/src/vlaai/*"
+  - changed-files:
+    - any-glob-to-any-file: "*/src/vlaai/*"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -163,8 +163,8 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
       },
     ];
     const lExpected = `# some header or other${EOL}baarden:
-- changed-files:
-  - any-glob-to-any-file: src/vlaai/**
+  - changed-files:
+    - any-glob-to-any-file: src/vlaai/**
 
 `;
     equal(

--- a/src/labeler-yml/generate.test.ts
+++ b/src/labeler-yml/generate.test.ts
@@ -83,7 +83,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
     ];
     const lExpected = `the-a-team:
   - changed-files:
-    - any-glob-to-any-file: knakkerdeknak/**
+      - any-glob-to-any-file: knakkerdeknak/**
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -110,7 +110,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
     ];
     const lExpected = `baarden:
   - changed-files:
-    - any-glob-to-any-file: "**"
+      - any-glob-to-any-file: "**"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -137,7 +137,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
     ];
     const lExpected = `baarden:
   - changed-files:
-    - any-glob-to-any-file: "*/src/vlaai/*"
+      - any-glob-to-any-file: "*/src/vlaai/*"
 
 `;
     equal(generateLabelerYml(lVirtualCodeOwners, TEAMS, ""), lExpected);
@@ -164,7 +164,7 @@ describe("generate-labeler-yml generates a labeler.yml", () => {
     ];
     const lExpected = `# some header or other${EOL}baarden:
   - changed-files:
-    - any-glob-to-any-file: src/vlaai/**
+      - any-glob-to-any-file: src/vlaai/**
 
 `;
     equal(

--- a/src/labeler-yml/generate.ts
+++ b/src/labeler-yml/generate.ts
@@ -26,7 +26,7 @@ export default function generateLabelerYml(
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
       .map(
         (pPattern) =>
-          `    - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+          `      - any-glob-to-any-file: ${transformForYamlAndMinimatch(
             pPattern,
           )}${EOL}`,
       )

--- a/src/labeler-yml/generate.ts
+++ b/src/labeler-yml/generate.ts
@@ -26,14 +26,14 @@ export default function generateLabelerYml(
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
       .map(
         (pPattern) =>
-          `  - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+          `    - any-glob-to-any-file: ${transformForYamlAndMinimatch(
             pPattern,
           )}${EOL}`,
       )
       .join("");
 
     if (lPatternsForTeam) {
-      lReturnValue += `${lTeamName}:${EOL}- changed-files:${EOL}${lPatternsForTeam}${EOL}`;
+      lReturnValue += `${lTeamName}:${EOL}  - changed-files:${EOL}${lPatternsForTeam}${EOL}`;
     }
   }
   return lReturnValue;

--- a/src/labeler-yml/generate.ts
+++ b/src/labeler-yml/generate.ts
@@ -24,11 +24,16 @@ export default function generateLabelerYml(
   let lReturnValue = pGeneratedWarning;
   for (const lTeamName in pTeamMap) {
     const lPatternsForTeam = getPatternsForTeam(pCodeOwners, lTeamName)
-      .map((pPattern) => `  - ${transformForYamlAndMinimatch(pPattern)}${EOL}`)
+      .map(
+        (pPattern) =>
+          `  - any-glob-to-any-file: ${transformForYamlAndMinimatch(
+            pPattern,
+          )}${EOL}`,
+      )
       .join("");
 
     if (lPatternsForTeam) {
-      lReturnValue += `${lTeamName}:${EOL}${lPatternsForTeam}${EOL}`;
+      lReturnValue += `${lTeamName}:${EOL}- changed-files:${EOL}${lPatternsForTeam}${EOL}`;
     }
   }
   return lReturnValue;


### PR DESCRIPTION
## Description

- changes the --emitLabeler output so it supports the labeler v5 format

## Motivation and Context

actions/labeler [changed their configuration format in a breaking fashion](https://github.com/actions/labeler/issues/712)


## How Has This Been Tested?

- [x] green ci
- [x] updated non-regression tests
- [x] generating a labeler.yml and running it against the new version of actions/labeler - see [action run 7194463872](https://github.com/sverweij/virtual-code-owners/actions/runs/7194463872/job/19595044485?pr=163)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
