### PR TITLE
refactor(team-map): replaces 'ajv' with a hand-rolled validation

### DIFF
--- a/dist/team-map/read.js
+++ b/dist/team-map/read.js
@@ -1,8 +1,6 @@
-import Ajv from "ajv";
 import { readFileSync } from "node:fs";
-import { EOL } from "node:os";
 import { parse as parseYaml } from "yaml";
-import virtualTeamsSchema from "./virtual-teams.schema.js";
+import { EOL } from "node:os";
 export default function readTeamMap(pVirtualTeamsFileName) {
 	const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
 		encoding: "utf-8",
@@ -11,22 +9,74 @@ export default function readTeamMap(pVirtualTeamsFileName) {
 	assertTeamMapValid(lTeamMap, pVirtualTeamsFileName);
 	return lTeamMap;
 }
-function assertTeamMapValid(pTeamMap, pVirtualTeamsFileName) {
-	const ajv = new Ajv({
-		allErrors: true,
-		verbose: true,
-	});
-	if (!ajv.validate(virtualTeamsSchema, pTeamMap)) {
+function assertTeamMapValid(pTeamMapCandidate, pVirtualTeamsFileName) {
+	const [lValid, lError] = validateTeamMap(pTeamMapCandidate);
+	if (!lValid) {
 		throw new Error(
-			`This is not a valid virtual-teams.yml:${EOL}${formatAjvErrors(ajv.errors, pVirtualTeamsFileName)}.\n`,
+			`'${pVirtualTeamsFileName}' is not a valid virtual-teams.yml:${EOL}  ${lError}`,
 		);
 	}
 }
-function formatAjvErrors(pAjvErrors, pVirtualTeamsFileName) {
-	return pAjvErrors
-		.map((pAjvError) => formatAjvError(pAjvError, pVirtualTeamsFileName))
-		.join(EOL);
+function validateTeamMap(pCandidateTeamMap) {
+	if (
+		typeof pCandidateTeamMap !== "object" ||
+		pCandidateTeamMap === null ||
+		Array.isArray(pCandidateTeamMap)
+	) {
+		return [false, "The team map is not an object"];
+	}
+	const lTeamNameResults = Object.keys(pCandidateTeamMap).map(validateTeamName);
+	const lErrors = lTeamNameResults.filter((result) => !result[0]);
+	if (lErrors.length > 0) {
+		return [
+			false,
+			`These team names are not valid: ${lErrors.map((error) => error[1]).join(", ")}`,
+		];
+	}
+	const lTeamResults = Object.keys(pCandidateTeamMap).map((pKey) =>
+		validateTeam(pCandidateTeamMap[pKey], pKey),
+	);
+	const lTeamErrors = lTeamResults.filter((result) => !result[0]);
+	if (lTeamErrors.length > 0) {
+		return [false, lTeamErrors.map((error) => error[1]).join(`, ${EOL}  `)];
+	}
+	return [true];
 }
-function formatAjvError(pAjvError, pVirtualTeamsFileName) {
-	return `${pVirtualTeamsFileName}: ${pAjvError.instancePath} - ${JSON.stringify(pAjvError.data)} ${pAjvError.message}`;
+function validateTeamName(pTeamNameCandidate) {
+	if (typeof pTeamNameCandidate !== "string") {
+		return [false, "not a string"];
+	}
+	if (pTeamNameCandidate === "") {
+		return [false, "'' (empty string)"];
+	}
+	if (pTeamNameCandidate.includes(" ")) {
+		return [false, `'${pTeamNameCandidate}' (contains spaces)`];
+	}
+	return [true];
+}
+function validateTeam(pCandidateTeam, pTeamName) {
+	if (!Array.isArray(pCandidateTeam)) {
+		return [false, `This team is not an array: '${pTeamName}'`];
+	}
+	const lTeamMemberResults = pCandidateTeam.map(validateTeamMember);
+	const lErrors = lTeamMemberResults.filter((result) => !result[0]);
+	if (lErrors.length > 0) {
+		return [false, lErrors.map((error) => error[1]).join(", ")];
+	}
+	return [true];
+}
+function validateTeamMember(pTeamMemberCandidate) {
+	if (typeof pTeamMemberCandidate !== "string") {
+		return [
+			false,
+			`This username is not a string: '${pTeamMemberCandidate.toString()}'`,
+		];
+	}
+	if (!/^[^@][^\s]+$/.test(pTeamMemberCandidate)) {
+		return [
+			false,
+			`This username doesn't match /^[^@][^\\s]+$/: '${pTeamMemberCandidate}'`,
+		];
+	}
+	return [true];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.13.0",
         "yaml": "2.4.2"
       },
       "bin": {
@@ -507,6 +506,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -1014,7 +1014,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
@@ -1444,7 +1445,8 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1958,6 +1960,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1996,6 +1999,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2409,6 +2413,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "watskeburt": "4.0.2"
   },
   "dependencies": {
-    "ajv": "8.13.0",
     "yaml": "2.4.2"
   },
   "engines": {

--- a/src/__mocks__/erroneous-virtual-team-is-an-array.yml
+++ b/src/__mocks__/erroneous-virtual-team-is-an-array.yml
@@ -1,0 +1,6 @@
+- a_team_map
+  - should be
+  - a_map
+- and_not
+  - an
+  - array

--- a/src/__mocks__/erroneous-virtual-team-names.yml
+++ b/src/__mocks__/erroneous-virtual-team-names.yml
@@ -1,0 +1,5 @@
+: - hasmembersbut
+  - teamnameisempty
+team name with spaces:
+  - isnot
+  - allowedeither

--- a/src/__mocks__/erroneous-virtual-teams.yml
+++ b/src/__mocks__/erroneous-virtual-teams.yml
@@ -32,6 +32,7 @@ ch/transversal:
   - benjamin-franklin
   - koos-koets
   - abraham-lincoln
+  - 123456789
 ch/mannen-met-baarden: arie
   - jan@example.com
   - pier@example.com

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -59,10 +59,12 @@ describe("cli", () => {
   it("shows an error when passed an invalid virtual-teams file", () => {
     let lOutStream = new WritableTestStream();
     let lErrStream = new WritableTestStream([
-      /ERROR: This is not a valid virtual-teams\.yml:/,
-      /src\/__mocks__\/erroneous\-virtual\-teams\.yml: \/ch~1after-sales\/3 - "@daisy-duck" must match pattern/,
-      /src\/__mocks__\/erroneous\-virtual\-teams\.yml: \/ch~1pre-sales\/3 - "john-galt-ch dagny-taggert-ch" must match pattern/,
-      /src\/__mocks__\/erroneous-virtual-teams.yml: \/ch~1mannen-met-baarden - "arie - jan@example.com - pier@example.com - tjorus@example.com - korneel@example.com" must be array/,
+      /ERROR:/,
+      /is not a valid virtual-teams\.yml:/,
+      /This username doesn't match .+: '@daisy-duck'/,
+      /This username doesn't match .+: 'john-galt-ch dagny-taggert-ch'/,
+      /This username is not a string: '123456789'/,
+      /This team is not an array: 'ch\/mannen-met-baarden'/,
     ]);
     cli(
       [
@@ -70,6 +72,56 @@ describe("cli", () => {
         "./src/__mocks__/virtual-codeowners.txt",
         "--virtualTeams",
         "./src/__mocks__/erroneous-virtual-teams.yml",
+        "--codeOwners",
+        "node_modules/tmp-code-owners.txt",
+        "--emitLabeler",
+        "--labelerLocation",
+        "node_modules/tmp-labeler.yml",
+      ],
+      lOutStream,
+      lErrStream,
+      0,
+    );
+  });
+
+  it("shows an error when passed an invalid virtual-teams file (invalid names)", () => {
+    let lOutStream = new WritableTestStream();
+    let lErrStream = new WritableTestStream([
+      /ERROR:/,
+      /is not a valid virtual-teams\.yml:/,
+      /These team names are not valid: '' \(empty string\), 'team name with spaces' \(contains spaces\)/,
+    ]);
+    cli(
+      [
+        "--virtualCodeOwners",
+        "./src/__mocks__/virtual-codeowners.txt",
+        "--virtualTeams",
+        "./src/__mocks__/erroneous-virtual-team-names.yml",
+        "--codeOwners",
+        "node_modules/tmp-code-owners.txt",
+        "--emitLabeler",
+        "--labelerLocation",
+        "node_modules/tmp-labeler.yml",
+      ],
+      lOutStream,
+      lErrStream,
+      0,
+    );
+  });
+
+  it("shows an error when passed an invalid virtual-teams file (not an object)", () => {
+    let lOutStream = new WritableTestStream();
+    let lErrStream = new WritableTestStream([
+      /ERROR:/,
+      /is not a valid virtual-teams\.yml:/,
+      /The team map is not an object/,
+    ]);
+    cli(
+      [
+        "--virtualCodeOwners",
+        "./src/__mocks__/virtual-codeowners.txt",
+        "--virtualTeams",
+        "./src/__mocks__/erroneous-virtual-team-is-an-array.yml",
         "--codeOwners",
         "node_modules/tmp-code-owners.txt",
         "--emitLabeler",

--- a/src/team-map/read.ts
+++ b/src/team-map/read.ts
@@ -1,9 +1,9 @@
-import Ajv from "ajv";
 import { readFileSync } from "node:fs";
-import { EOL } from "node:os";
 import type { ITeamMap } from "./team-map.js";
 import { parse as parseYaml } from "yaml";
-import virtualTeamsSchema from "./virtual-teams.schema.js";
+import { EOL } from "node:os";
+
+type BooleanResultType = [value: boolean, error?: string];
 
 export default function readTeamMap(pVirtualTeamsFileName: string): ITeamMap {
   const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
@@ -15,35 +15,97 @@ export default function readTeamMap(pVirtualTeamsFileName: string): ITeamMap {
   return lTeamMap;
 }
 
-function assertTeamMapValid(pTeamMap: ITeamMap, pVirtualTeamsFileName: string) {
-  //@ts-expect-error typescript can't find a constructor in the type declaration.
-  // This _works_, though and is the canonical way to work with ajv
-  const ajv = new Ajv({
-    allErrors: true,
-    verbose: true,
-  });
-
-  if (!ajv.validate(virtualTeamsSchema, pTeamMap)) {
+function assertTeamMapValid(
+  pTeamMapCandidate: any,
+  pVirtualTeamsFileName: string,
+) {
+  const [lValid, lError] = validateTeamMap(pTeamMapCandidate);
+  if (!lValid) {
     throw new Error(
-      `This is not a valid virtual-teams.yml:${EOL}${formatAjvErrors(
-        ajv.errors as any[],
-        pVirtualTeamsFileName,
-      )}.\n`,
+      `'${pVirtualTeamsFileName}' is not a valid virtual-teams.yml:${EOL}  ${lError}`,
     );
   }
 }
 
-function formatAjvErrors(
-  pAjvErrors: any[],
-  pVirtualTeamsFileName: string,
-): string {
-  return pAjvErrors
-    .map((pAjvError) => formatAjvError(pAjvError, pVirtualTeamsFileName))
-    .join(EOL);
+function validateTeamMap(pCandidateTeamMap: any): BooleanResultType {
+  if (
+    typeof pCandidateTeamMap !== "object" ||
+    pCandidateTeamMap === null ||
+    Array.isArray(pCandidateTeamMap)
+  ) {
+    return [false, "The team map is not an object"];
+  }
+
+  const lTeamNameResults = Object.keys(pCandidateTeamMap).map(validateTeamName);
+  const lErrors = lTeamNameResults.filter((result) => !result[0]);
+
+  if (lErrors.length > 0) {
+    return [
+      false,
+      `These team names are not valid: ${lErrors.map((error) => error[1]).join(", ")}`,
+    ];
+  }
+
+  const lTeamResults = Object.keys(pCandidateTeamMap).map((pKey) =>
+    validateTeam(pCandidateTeamMap[pKey], pKey),
+  );
+  const lTeamErrors = lTeamResults.filter((result) => !result[0]);
+
+  if (lTeamErrors.length > 0) {
+    return [false, lTeamErrors.map((error) => error[1]).join(`, ${EOL}  `)];
+  }
+
+  return [true];
 }
 
-function formatAjvError(pAjvError: any, pVirtualTeamsFileName: string): string {
-  return `${pVirtualTeamsFileName}: ${
-    pAjvError.instancePath
-  } - ${JSON.stringify(pAjvError.data)} ${pAjvError.message}`;
+function validateTeamName(pTeamNameCandidate: any): BooleanResultType {
+  /* c8 ignore start */
+  // seemingly, yaml keys are always (converted to) strings (automatically)
+  // (tried 123, 123.45, true, false, null, [], {}). It's handy
+  // as a type guard, though
+  if (typeof pTeamNameCandidate !== "string") {
+    return [false, "not a string"];
+  }
+  /* c8 ignore stop */
+  if (pTeamNameCandidate === "") {
+    return [false, "'' (empty string)"];
+  }
+
+  if (pTeamNameCandidate.includes(" ")) {
+    return [false, `'${pTeamNameCandidate}' (contains spaces)`];
+  }
+  return [true];
+}
+
+function validateTeam(
+  pCandidateTeam: any,
+  pTeamName: string,
+): BooleanResultType {
+  if (!Array.isArray(pCandidateTeam)) {
+    return [false, `This team is not an array: '${pTeamName}'`];
+  }
+  const lTeamMemberResults = pCandidateTeam.map(validateTeamMember);
+  const lErrors = lTeamMemberResults.filter((result) => !result[0]);
+
+  if (lErrors.length > 0) {
+    return [false, lErrors.map((error) => error[1]).join(", ")];
+  }
+
+  return [true];
+}
+
+function validateTeamMember(pTeamMemberCandidate: any): BooleanResultType {
+  if (typeof pTeamMemberCandidate !== "string") {
+    return [
+      false,
+      `This username is not a string: '${pTeamMemberCandidate.toString()}'`,
+    ];
+  }
+  if (!/^[^@][^\s]+$/.test(pTeamMemberCandidate)) {
+    return [
+      false,
+      `This username doesn't match /^[^@][^\\s]+$/: '${pTeamMemberCandidate}'`,
+    ];
+  }
+  return [true];
 }


### PR DESCRIPTION
## Description

- replaces the validation of the team map in ajv with a simple hand-rolled one
- removes the 3rd party production dependency 'ajv'

## Motivation and Context

Less dependencies = less worries. Ajv is b.t.w. a great & well maintained package, but for validating the tiny team maps it's overkill. It also makes virtual-code-owners' footprint smaller (ajv is ~120kb minified/ ~35kb compressed - compared to vco itself which has the numbers ~27kb/ ~9kb).

## How Has This Been Tested?

- [x] green ci
- [x] additional non-regression integration tests (we have to test a bit more now, but also the error messages can be easier made to fit to our use case).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
