### PR TITLE
docs(README): removes gotcha that sections wouldn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,6 @@ libs/baarden/       jan@example.com korneel@example.com pier@example.com tjorus@
 ### Any gotcha's?
 
 - It won't check whether the users or teams you entered exist.
-- Only relevant when you're on GitLab: Section heading support is experimental
-  and when generating labeler.yml default section owners aren't expanded to
-  section rules.
 
 ### Do I have to run this each time I edit `VIRTUAL-CODEOWNERS.txt`?
 


### PR DESCRIPTION
## Description

- removes gotcha that sections wouldn't work

## Motivation and Context

ain't true anymore 

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
