### PR TITLE
fix: opens input files explicitly readonly

### DIFF
--- a/dist/team-map/read.js
+++ b/dist/team-map/read.js
@@ -4,6 +4,7 @@ import { EOL } from "node:os";
 export default function readTeamMap(pVirtualTeamsFileName) {
 	const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
 		encoding: "utf-8",
+		flag: "r",
 	});
 	const lTeamMap = parseYaml(lVirtualTeamsAsAString);
 	assertTeamMapValid(lTeamMap, pVirtualTeamsFileName);

--- a/dist/virtual-code-owners/read.js
+++ b/dist/virtual-code-owners/read.js
@@ -8,6 +8,7 @@ export default function readVirtualCodeOwners(
 ) {
 	const lVirtualCodeOwnersAsAString = readFileSync(pVirtualCodeOwnersFileName, {
 		encoding: "utf-8",
+		flag: "r",
 	});
 	const lVirtualCodeOwners = parseVirtualCodeOwners(
 		lVirtualCodeOwnersAsAString,

--- a/src/team-map/read.ts
+++ b/src/team-map/read.ts
@@ -8,6 +8,7 @@ type BooleanResultType = [value: boolean, error?: string];
 export default function readTeamMap(pVirtualTeamsFileName: string): ITeamMap {
   const lVirtualTeamsAsAString = readFileSync(pVirtualTeamsFileName, {
     encoding: "utf-8",
+    flag: "r",
   });
   const lTeamMap = parseYaml(lVirtualTeamsAsAString) as ITeamMap;
   assertTeamMapValid(lTeamMap, pVirtualTeamsFileName);

--- a/src/virtual-code-owners/read.ts
+++ b/src/virtual-code-owners/read.ts
@@ -11,6 +11,7 @@ export default function readVirtualCodeOwners(
 ): IVirtualCodeOwnersCST {
   const lVirtualCodeOwnersAsAString = readFileSync(pVirtualCodeOwnersFileName, {
     encoding: "utf-8",
+    flag: "r",
   });
   const lVirtualCodeOwners = parseVirtualCodeOwners(
     lVirtualCodeOwnersAsAString,


### PR DESCRIPTION
## Description

- opens the virtual-teams.yml and virtual-codeowners.txt explicitly as read only

... so there's less chance for accidents - and other process who want to read the files have a better chance.

## How Has This Been Tested?

- [x] green ci

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
