### PR TITLE
fix(virtual-code-owners/parse): uses a platform independent regex instead of os.EOL

### DIFF
--- a/dist/virtual-code-owners/parse.js
+++ b/dist/virtual-code-owners/parse.js
@@ -1,4 +1,3 @@
-import { EOL } from "node:os";
 import { isEmailIshUsername } from "../utensils.js";
 let STATE = {
 	currentSection: "",
@@ -10,7 +9,7 @@ export function parse(pVirtualCodeOwnersAsString, pTeamMap = {}) {
 		inheritedUsers: [],
 	};
 	return pVirtualCodeOwnersAsString
-		.split(EOL)
+		.split(/\r?\n/)
 		.map((pUntreatedLine, pLineNo) =>
 			parseLine(pUntreatedLine, pTeamMap, pLineNo + 1),
 		);

--- a/src/virtual-code-owners/parse.test.ts
+++ b/src/virtual-code-owners/parse.test.ts
@@ -56,3 +56,30 @@ describe("parses VIRTUAL-CODEOWNERS.txt - with 'virtual teams'", () => {
       });
     });
 });
+describe("parse - parsing regular expressions", () => {
+  it("handles windows and unix line endings regardless of os", () => {
+    const lInputWindowsEOLs = "# a comment\r\n*.js @team";
+    const lInputUnixEOLs = "# a comment\n*.js @team";
+    const lResult = [
+      { type: "comment", line: 1, raw: "# a comment" },
+      {
+        type: "rule",
+        line: 2,
+        raw: "*.js @team",
+        filesPattern: "*.js",
+        spaces: " ",
+        users: [
+          {
+            type: "other-user-or-team",
+            userNumberWithinLine: 1,
+            bareName: "team",
+            raw: "@team",
+          },
+        ],
+        inlineComment: "",
+      },
+    ];
+    deepEqual(parse(lInputWindowsEOLs, TEAMS_EMPTY), lResult);
+    deepEqual(parse(lInputUnixEOLs, TEAMS_EMPTY), lResult);
+  });
+});

--- a/src/virtual-code-owners/parse.ts
+++ b/src/virtual-code-owners/parse.ts
@@ -32,7 +32,7 @@ export function parse(
       // os.EOL looks like the better choice here, however, even though os.EOL
       // might report `\n` as a line ending, what we read in that repo
       // might still use `\r\n` as a line ending - or the other way around.
-      // Hence, for parsing, we use this platform independent regex in stead.
+      // Hence, for parsing, we use this platform independent regex instead.
       .split(/\r?\n/)
       .map((pUntreatedLine, pLineNo) =>
         parseLine(pUntreatedLine, pTeamMap, pLineNo + 1),

--- a/src/virtual-code-owners/parse.ts
+++ b/src/virtual-code-owners/parse.ts
@@ -1,4 +1,3 @@
-import { EOL } from "node:os";
 import type { ITeamMap } from "../team-map/team-map.js";
 import type {
   IRuleCSTLine,
@@ -28,11 +27,17 @@ export function parse(
     currentSection: "",
     inheritedUsers: [],
   };
-  return pVirtualCodeOwnersAsString
-    .split(EOL)
-    .map((pUntreatedLine, pLineNo) =>
-      parseLine(pUntreatedLine, pTeamMap, pLineNo + 1),
-    );
+  return (
+    pVirtualCodeOwnersAsString
+      // os.EOL looks like the better choice here, however, even though os.EOL
+      // might report `\n` as a line ending, what we read in that repo
+      // might still use `\r\n` as a line ending - or the other way around.
+      // Hence, for parsing, we use this platform independent regex in stead.
+      .split(/\r?\n/)
+      .map((pUntreatedLine, pLineNo) =>
+        parseLine(pUntreatedLine, pTeamMap, pLineNo + 1),
+      )
+  );
 }
 
 function parseLine(


### PR DESCRIPTION
## Description
- uses a platform independent regex instead of os.EOL for parsing EOL
see comment in committed code for rationale

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
