### PR TITLE
chore(ci): small improvements to semantic pr title workflow

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -6,14 +6,21 @@ on:
       - opened
       - edited
       - synchronize
+    branches:
+      - main
 
 permissions:
   pull-requests: read
+
+concurrency:
+  group: semantic-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   main:
     name: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@45b9ed7cf24087a2f7785bf55be97394ba87e1c2
         env:


### PR DESCRIPTION
## Description

Makes small updates to the semantic par title workflow
- ensure it only runs agains the `main` branch
- cancel old flows that might still be running on the same PR
- sets a timeout so if there's an issue on the GitHub runner it doesn't keep running unnecessarily (and burn runner minutes)

## How Has This Been Tested?

- [x] green ci
- [ ] verified whether it works in the context of this PR


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).