### PR TITLE
chore(npm): makes publishing staged only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,21 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 26.x
           registry-url: https://registry.npmjs.org
+      # staged publishing works as of npm@11.15.0. Until that that or higher is
+      # shipped with nodejs by default we need to install it manually.
+      - run: npm install -g npm@^11.15.0
+      - name: print node & npm versions
+        run: |
+          node --version
+          npm --version
       - run: npm clean-install
+      - run: node --run=build
+      - run: node --run=test
       - name: publish as latest
-        run: npm publish --provenance --access public
+        run: npm staged publish --provenance --access public
         if: github.event.release.prerelease == false
       - name: publish as beta
-        run: npm publish --provenance --access public --tag beta
+        run: npm staged publish --provenance --access public --tag beta
         if: github.event.release.prerelease == true


### PR DESCRIPTION
## Description

- makes publishing 'staged' only
- 🏕️ sets the runner's node version to 26
- 🏕️ adds a build and test verification step to the publish workflow

## Motivation and Context

Should lessen the chance malicious parties do something naughty to.

## How Has This Been Tested?

- [x] green ci
- we only know it works when we actually publish a thing, but a _very_ similar setup in state-machine-cat has been proven to work this morning.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (thing that needs doing without adding functionality)

## Checklist

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/virtual-code-owners/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/virtual-code-owners/blob/main/.github/CONTRIBUTING.md).
